### PR TITLE
Update present version of cli.py to download only last available processing baseline for Sentinel2 collection

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
         with:
           args: 'format --check --diff'
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
@@ -41,7 +41,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,11 +6,11 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: astral-sh/ruff-action@0c50076f12c38c3d0115b7b519b54a91cb9cf0ad # v3.5.0
         with:
           args: 'format --check --diff'
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@0c50076f12c38c3d0115b7b519b54a91cb9cf0ad # v3.5.0
         with:
           args: 'check'
 
@@ -20,9 +20,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -39,13 +39,13 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .[test]
-      - uses: jakebailey/pyright-action@v2
+      - uses: jakebailey/pyright-action@b5d50e5cde6547546a5c4ac92e416a8c2c1a1dfe # v2.3.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
         with:
           args: 'format --check --diff'
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
@@ -41,7 +41,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
         with:
           args: 'format --check --diff'
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
@@ -41,7 +41,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
         with:
           args: 'format --check --diff'
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -41,7 +41,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,4 +50,4 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[test]
-      - uses: jakebailey/pyright-action@6cabc0f01c4994be48fd45cd9dbacdd6e1ee6e5e # v2.3.3
+      - uses: jakebailey/pyright-action@8ec14b5cfe41f26e5f41686a31eb6012758217ef # v3.0.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
         with:
           args: 'format --check --diff'
-      - uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
         with:
           args: 'check'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,4 +48,4 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[test]
-      - uses: jakebailey/pyright-action@b5d50e5cde6547546a5c4ac92e416a8c2c1a1dfe # v2.3.2
+      - uses: jakebailey/pyright-action@6cabc0f01c4994be48fd45cd9dbacdd6e1ee6e5e # v2.3.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: astral-sh/ruff-action@0c50076f12c38c3d0115b7b519b54a91cb9cf0ad # v3.5.0
+      - uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
         with:
           args: 'format --check --diff'
-      - uses: astral-sh/ruff-action@0c50076f12c38c3d0115b7b519b54a91cb9cf0ad # v3.5.0
+      - uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
         with:
           args: 'check'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: Lint
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: astral-sh/ruff-action@0c50076f12c38c3d0115b7b519b54a91cb9cf0ad # v3.5.0
         with:
           args: 'format --check --diff'
@@ -20,7 +20,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
@@ -39,7 +39,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Set up Python
       uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Set up Python
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
     - name: Set up Python
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Set up Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
     - name: Set up Python
-      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Set up Python
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,7 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   deploy:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     branches: [ "main" ]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   pytest:
@@ -15,9 +14,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-    permissions:
-      pull-requests: write
-      contents: write
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,9 +19,9 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
       run: |
         pytest --cov=cdsetool --cov-report xml
 #     - name: Python Coverage
-#       uses: orgoro/coverage@v3.1
+#       uses: orgoro/coverage@3f13a558c5af7376496aa4848bf0224aead366ac # v3.2
 #       with:
 #           coverageFile: coverage.xml
 #           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
+      uses: github/codeql-action/upload-sarif@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.30.0
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Run vulnerability scanner
       uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
       with:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@64d10c13136e1c5bce3e5fbde8d4906eeaafc885 # v3.30.6
+      uses: github/codeql-action/upload-sarif@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
+      uses: github/codeql-action/upload-sarif@303c0aef88fc2fe5ff6d63d3b1596bfd83dfa1f9 # v3.30.4
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
+      uses: github/codeql-action/upload-sarif@19b2f06db2b6f5108140aeb04014ef02b648f789 # v4.31.11
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3
+      uses: github/codeql-action/upload-sarif@e12f0178983d466f2f6028f5cc7a6d786fd97f4b # v4.31.4
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
+      uses: github/codeql-action/upload-sarif@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v4.31.0
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@cf1bb45a277cb3c205638b2cd5c984db1c46a412 # v4.31.7
+      uses: github/codeql-action/upload-sarif@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@f1f6e5f6af878fb37288ce1c627459e94dbf7d01 # v3.30.1
+      uses: github/codeql-action/upload-sarif@d3678e237b9c32a6c9bffb3315c335f976f3549f # v3.30.2
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
     - name: Run vulnerability scanner
       uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
       with:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.30.0
+      uses: github/codeql-action/upload-sarif@f1f6e5f6af878fb37288ce1c627459e94dbf7d01 # v3.30.1
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7
+      uses: github/codeql-action/upload-sarif@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+      uses: github/codeql-action/upload-sarif@6bc82e05fd0ea64601dd4b465378bbcf57de0314 # v4.32.1
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@d3678e237b9c32a6c9bffb3315c335f976f3549f # v3.30.2
+      uses: github/codeql-action/upload-sarif@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5
+      uses: github/codeql-action/upload-sarif@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Run vulnerability scanner
-      uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
+      uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
       with:
         scan-type: 'fs'
         ignore-unfixed: true

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Run vulnerability scanner
-      uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # 0.32.0
+      uses: aquasecurity/trivy-action@f9424c10c36e288d5fa79bd3dfd1aeb2d6eae808 # 0.33.0
       with:
         scan-type: 'fs'
         ignore-unfixed: true

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Run vulnerability scanner
       uses: aquasecurity/trivy-action@f9424c10c36e288d5fa79bd3dfd1aeb2d6eae808 # 0.33.0
       with:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4.31.8
+      uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Run vulnerability scanner
-      uses: aquasecurity/trivy-action@f9424c10c36e288d5fa79bd3dfd1aeb2d6eae808 # 0.33.0
+      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
       with:
         scan-type: 'fs'
         ignore-unfixed: true

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v4.31.0
+      uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@19b2f06db2b6f5108140aeb04014ef02b648f789 # v4.31.11
+      uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Run vulnerability scanner
       uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
       with:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Run vulnerability scanner
       uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
       with:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@e12f0178983d466f2f6028f5cc7a6d786fd97f4b # v4.31.4
+      uses: github/codeql-action/upload-sarif@fdbfb4d2750291e159f0156def62b853c2798ca2 # v4.31.5
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v4.31.2
+      uses: github/codeql-action/upload-sarif@014f16e7ab1402f30e7c3329d33797e7948572db # v4.31.3
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@6bc82e05fd0ea64601dd4b465378bbcf57de0314 # v4.32.1
+      uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,35 @@
+name: Scan
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  cve-scanner:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Run vulnerability scanner
+      uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # 0.32.0
+      with:
+        scan-type: 'fs'
+        ignore-unfixed: true
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+        severity: 'MEDIUM,HIGH,CRITICAL'
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
+      with:
+        sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
+      uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6
+      uses: github/codeql-action/upload-sarif@cf1bb45a277cb3c205638b2cd5c984db1c46a412 # v4.31.7
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Run vulnerability scanner
-      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+      uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
       with:
         scan-type: 'fs'
         ignore-unfixed: true

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
+      uses: github/codeql-action/upload-sarif@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@303c0aef88fc2fe5ff6d63d3b1596bfd83dfa1f9 # v3.30.4
+      uses: github/codeql-action/upload-sarif@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
+      uses: github/codeql-action/upload-sarif@9e907b5e64f6b83e7804b09294d44122997950d6 # v4.32.3
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+      uses: github/codeql-action/upload-sarif@16140ae1a102900babc80a33c44059580f687047 # v4.30.9
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
+      uses: github/codeql-action/upload-sarif@64d10c13136e1c5bce3e5fbde8d4906eeaafc885 # v3.30.6
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
+      uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
       with:
         sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Run vulnerability scanner
-      uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+      uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
       with:
         scan-type: 'fs'
         ignore-unfixed: true

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Run vulnerability scanner
-      uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # 0.34.2
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
       with:
         scan-type: 'fs'
         ignore-unfixed: true

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -30,6 +30,6 @@ jobs:
         output: 'trivy-results.sarif'
         severity: 'MEDIUM,HIGH,CRITICAL'
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+      uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
       with:
         sarif_file: 'trivy-results.sarif'

--- a/README.md
+++ b/README.md
@@ -260,6 +260,32 @@ for feature in features:
     download_feature(feature, download_path)
 ```
 
+#### Download specific files within features
+
+It's possible to download specific files within products bundles using Unix filename pattern matching.
+
+It can be used in CDSETool:
+
+- Through the `filter_pattern` option of `download_features` and `download_feature`:
+    ```python
+    from cdsetool.query import query_features
+    from cdsetool.download import download_features
+
+    features = query_features("Sentinel2")
+
+    download_path = "/path/to/download/folder"
+    filter_pattern = "*TCI.jp2"
+    downloads = download_features(features, download_path, {"filter_pattern": filter_pattern})
+
+    for id in downloads:
+        print(f"feature {id} downloaded")
+    ```
+
+- Or through the CLI:
+    ```
+    cdsetool download Sentinel2 PATH/TO/DIR --filter-pattern *TCI.jp2 --concurrency 4 --search-term startDate=2020-01-01 --search-term completionDate=2020-01-10 --search-term processingLevel=S2MSI2A --search-term box="4","51","4.5","52"
+    ```
+
 ## Roadmap
 
 - [X] Query schema validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 [project.optional-dependencies]
 test = [
     "pylint==3.3.8",
-    "pytest==8.4.1",
+    "pytest==8.4.2",
     "pytest-cov==6.2.1",
     "requests-mock==1.12.1",
     "pytest-mock==3.14.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.5",
+    "ruff==0.14.6",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
 # leave the optional dependencies for everything except Ruff.
 [project.optional-dependencies]
 test = [
-    "pylint==3.3.8",
+    "pylint==3.3.9",
     "pytest==8.4.2",
     "pytest-cov==7.0.0",
     "requests-mock==1.12.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.12.9",
+    "ruff==0.12.10",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.0",
+    "ruff==0.14.1",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.6",
+    "ruff==0.14.7",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.15.2",
+    "ruff==0.15.4",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 [project.optional-dependencies]
 test = [
     "pylint==3.3.7",
-    "pytest==8.4.0",
+    "pytest==8.4.1",
     "pytest-cov==6.2.1",
     "requests-mock==1.12.1",
     "pytest-mock==3.14.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
 test = [
     "pylint==3.3.8",
     "pytest==8.4.2",
-    "pytest-cov==6.2.1",
+    "pytest-cov==6.3.0",
     "requests-mock==1.12.1",
     "pytest-mock==3.15.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.12.10",
+    "ruff==0.12.11",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ test = [
     "pytest==8.4.2",
     "pytest-cov==6.2.1",
     "requests-mock==1.12.1",
-    "pytest-mock==3.14.1",
+    "pytest-mock==3.15.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.15.1",
+    "ruff==0.15.2",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.9.3",
+    "ruff==0.12.7",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.9",
+    "ruff==0.14.10",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.13.3",
+    "ruff==0.14.0",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
 test = [
     "pylint==3.3.7",
     "pytest==8.4.0",
-    "pytest-cov==6.2.0",
+    "pytest-cov==6.2.1",
     "requests-mock==1.12.1",
     "pytest-mock==3.14.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.12.11",
+    "ruff==0.12.12",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
 # leave the optional dependencies for everything except Ruff.
 [project.optional-dependencies]
 test = [
-    "pylint==3.3.7",
+    "pylint==3.3.8",
     "pytest==8.4.1",
     "pytest-cov==6.2.1",
     "requests-mock==1.12.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.7",
+    "ruff==0.14.8",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.4",
+    "ruff==0.14.5",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 [project.optional-dependencies]
 test = [
     "pylint==3.3.4",
-    "pytest==8.3.4",
+    "pytest==8.3.5",
     "pytest-cov==6.0.0",
     "requests-mock==1.12.1",
     "pytest-mock==3.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.12.7",
+    "ruff==0.12.8",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.11",
+    "ruff==0.14.13",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
 test = [
     "pylint==3.3.8",
     "pytest==8.4.2",
-    "pytest-cov==6.3.0",
+    "pytest-cov==7.0.0",
     "requests-mock==1.12.1",
     "pytest-mock==3.15.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.13.0",
+    "ruff==0.13.1",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.14",
+    "ruff==0.15.0",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
 # leave the optional dependencies for everything except Ruff.
 [project.optional-dependencies]
 test = [
-    "pylint==3.3.4",
+    "pylint==3.3.7",
     "pytest==8.3.5",
     "pytest-cov==6.0.0",
     "requests-mock==1.12.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.8",
+    "ruff==0.14.9",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
   "typer >= 0.9,< 1",
-  "rich >= 13.6,< 14",
+  "rich >= 13.6,< 15",
   "requests >= 2.28.1,< 3",
   "pyjwt[crypto] >= 2.8,< 2.11",
   "geopandas >= 0.13.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.10",
+    "ruff==0.14.11",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ test = [
     "pytest==8.4.2",
     "pytest-cov==7.0.0",
     "requests-mock==1.12.1",
-    "pytest-mock==3.15.0",
+    "pytest-mock==3.15.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ test = [
     "pytest==8.3.5",
     "pytest-cov==6.1.1",
     "requests-mock==1.12.1",
-    "pytest-mock==3.14.0",
+    "pytest-mock==3.14.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
 test = [
     "pylint==3.3.7",
     "pytest==8.4.0",
-    "pytest-cov==6.1.1",
+    "pytest-cov==6.2.0",
     "requests-mock==1.12.1",
     "pytest-mock==3.14.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.1",
+    "ruff==0.14.2",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.12.12",
+    "ruff==0.13.0",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.13",
+    "ruff==0.14.14",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "typer >= 0.9,< 1",
   "rich >= 13.6,< 15",
   "requests >= 2.28.1,< 3",
-  "pyjwt[crypto] >= 2.8,< 2.11",
+  "pyjwt[crypto] >= 2.8,< 2.12",
   "geopandas >= 0.13.2",
 ]
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.12.8",
+    "ruff==0.12.9",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.13.2",
+    "ruff==0.13.3",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.15.0",
+    "ruff==0.15.1",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
 test = [
     "pylint==3.3.7",
     "pytest==8.3.5",
-    "pytest-cov==6.0.0",
+    "pytest-cov==6.1.1",
     "requests-mock==1.12.1",
     "pytest-mock==3.14.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.2",
+    "ruff==0.14.3",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.14.3",
+    "ruff==0.14.4",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 [project.optional-dependencies]
 test = [
     "pylint==3.3.7",
-    "pytest==8.3.5",
+    "pytest==8.4.0",
     "pytest-cov==6.1.1",
     "requests-mock==1.12.1",
     "pytest-mock==3.14.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.13.1",
+    "ruff==0.13.2",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 [dependency-groups]
 dev = [
-    "ruff==0.15.4",
+    "ruff==0.15.5",
 ]
 # (Jan 30 2025) Pip does not support dependency-groups yet, so
 # leave the optional dependencies for everything except Ruff.

--- a/src/cdsetool/cli.py
+++ b/src/cdsetool/cli.py
@@ -5,10 +5,9 @@ Command line interface
 import json as JSON
 import os
 import sys
-from typing import Dict, List, Optional
+from typing import Annotated, Dict, List, Optional
 
 import typer
-from typing_extensions import Annotated
 
 from cdsetool.download import download_features
 from cdsetool.monitor import StatusMonitor

--- a/src/cdsetool/cli.py
+++ b/src/cdsetool/cli.py
@@ -69,7 +69,7 @@ def query_search(
 
 # TODO: implement limit
 @app.command("download")
-def download(
+def download(  # pylint: disable=[too-many-arguments, too-many-positional-arguments]
     collection: str,
     path: str,
     concurrency: Annotated[
@@ -83,6 +83,15 @@ def download(
         typer.Option(
             help="Search by term=value pairs. "
             + "Pass multiple times for multiple search terms"
+        ),
+    ] = None,
+    filter_pattern: Annotated[
+        Optional[str],
+        typer.Option(
+            help=(
+                "Download specific files within product bundles using OData API's node"
+                " filtering functionality"
+            )
         ),
     ] = None,
 ) -> None:
@@ -104,6 +113,7 @@ def download(
                 "monitor": StatusMonitor(),
                 "concurrency": concurrency,
                 "overwrite_existing": overwrite_existing,
+                "filter_pattern": filter_pattern,
             },
         )
     )

--- a/src/cdsetool/download.py
+++ b/src/cdsetool/download.py
@@ -1,16 +1,20 @@
 """
 Download features from a Copernicus Data Space Ecosystem OpenSearch API result
 
-Provides a function to download a single feature, and a function to download
-all features in a result set.
+Provides a function to download a single feature, a function to download all features
+in a result set, and a function to download specific files in a given feature using
+node filtering.
 """
 
+import fnmatch
 import os
 import random
 import shutil
 import tempfile
 import time
-from typing import Any, Dict, Generator, Union
+from pathlib import Path
+from typing import Any, Dict, Generator, List, Union
+from xml.etree import ElementTree as ET
 
 from requests import Session
 from requests.exceptions import ChunkedEncodingError
@@ -26,31 +30,56 @@ from cdsetool.logger import NoopLogger
 from cdsetool.monitor import NoopMonitor, StatusMonitor
 from cdsetool.query import FeatureQuery
 
+MANIFEST_FILENAMES = {
+    "SENTINEL-1": "manifest.safe",
+    "SENTINEL-2": "manifest.safe",
+    "SENTINEL-3": "xfdumanifest.xml",
+}
 
-def download_feature(
-    feature, path: str, options: Union[Dict[str, Any], None] = None
-) -> Union[str, None]:
+
+def filter_files(
+    manifest_file: Path, pattern: Union[str, None], exclude: bool = False
+) -> Union[List[Path], None]:
     """
-    Download a single feature
+    Filter a product's files, listed in its manifest, based on a given pattern.
 
-    Returns the feature ID
+    Returns a list of file paths within the product bundle.
+
+    All files not matching the pattern are returned if "exclude" is set to true.
     """
-    options = options or {}
-    log = _get_logger(options)
-    url = _get_feature_url(feature)
-    title = feature.get("properties").get("title")
-    temp_dir_usr = _get_temp_dir(options)
 
-    if not url or not title:
-        log.debug(f"Bad URL ('{url}') or title ('{title}')")
+    def read_sentinel_manifest(manifest_file: Path) -> Union[List[Path], None]:
+        xmldoc = ET.parse(manifest_file)
+        section = xmldoc.find("dataObjectSection")
+        if section is None:
+            return None
+        paths = []
+        for obj in section.iterfind("dataObject"):
+            loc = obj.find("byteStream/fileLocation")
+            if loc is None:
+                return None
+            path = loc.get("href")
+            if path is None:
+                return None
+            paths.append(Path(path))
+        return paths
+
+    if pattern is None:
+        return []
+    paths = read_sentinel_manifest(manifest_file)
+    if paths is None:
         return None
+    return [path for path in paths if fnmatch.fnmatch(str(path), pattern) ^ exclude]
 
-    filename = title + ".zip"
-    result_path = os.path.join(path, filename)
 
-    if not options.get("overwrite_existing", False) and os.path.exists(result_path):
-        log.debug(f"File {result_path} already exists, skipping..")
-        return filename
+def download_file(url: str, path: Path, options: Dict[str, Any]) -> bool:
+    """
+    Download a single file.
+
+    Caller is responsible for ensuring that nothing else writes to path.
+    """
+    log = _get_logger(options)
+    filename = path.name
 
     with _get_monitor(options).status() as status:
         status.set_filename(filename)
@@ -67,27 +96,20 @@ def download_feature(
                 log.warning("Token signature expired, retrying..")
                 continue
             url = _follow_redirect(url, session)
-            name_dir_prefix = filename.replace(".zip", "____")
-            with (
-                session.get(url, stream=True) as response,
-                tempfile.TemporaryDirectory(
-                    prefix=name_dir_prefix, dir=temp_dir_usr
-                ) as temp_dir,
-            ):
+            with session.get(url, stream=True) as response:
                 if response.status_code != 200:
                     log.warning(f"Status code {response.status_code}, retrying..")
                     time.sleep(60 * (1 + (random.random() / 4)))
                     continue
 
                 status.set_filesize(int(response.headers["Content-Length"]))
-                tmp_file = os.path.join(temp_dir, "download.zip")
-                with open(tmp_file, "wb") as file:
+                with open(path, "wb") as outfile:
                     # Server might not send all bytes specified by the
                     # Content-Length header before closing connection.
                     # Log as a warning and try again.
                     try:
                         for chunk in response.iter_content(chunk_size=1024 * 1024 * 5):
-                            file.write(chunk)
+                            outfile.write(chunk)
                             status.add_progress(len(chunk))
                     except (
                         ChunkedEncodingError,
@@ -96,11 +118,81 @@ def download_feature(
                     ) as e:
                         log.warning(e)
                         continue
-                # Close file before copy so all buffers are flushed.
-                shutil.copy(tmp_file, result_path)
-                return filename
+                return True
+
     log.error(f"Failed to download {filename}")
-    return None
+    return False
+
+
+def download_feature(  # pylint: disable=too-many-return-statements
+    feature, path: str, options: Union[Dict[str, Any], None] = None
+) -> Union[str, None]:
+    """
+    Download a single feature.
+
+    Returns the feature title.
+    """
+    options = options or {}
+    log = _get_logger(options)
+    temp_dir_usr = _get_temp_dir(options)
+    title = feature.get("properties").get("title")
+    collection = feature.get("properties").get("collection")
+    download_full = "filter_pattern" not in options
+
+    try:
+        manifest_filename = "" if download_full else MANIFEST_FILENAMES[collection]
+    except KeyError:
+        log.error(
+            f"No support for downloading individual files in {collection} products"
+        )
+        return None
+
+    # Prepare to download full product, or manifest file if filter_pattern is used
+    filename = title + ".zip" if download_full else manifest_filename
+    url = (
+        _get_feature_url(feature)
+        if download_full
+        else _get_odata_url(feature["id"], title, filename)
+    )
+    if not url or not title:
+        log.debug(f"Bad URL ('{url}') or title ('{title}')")
+        return None
+
+    result_path = os.path.join(path, filename if download_full else title)
+    if not options.get("overwrite_existing", False) and os.path.exists(result_path):
+        log.debug(f"File {result_path} already exists, skipping..")
+        return os.path.basename(result_path)
+
+    with tempfile.TemporaryDirectory(
+        prefix=f"{title}____", dir=temp_dir_usr
+    ) as temp_dir:
+        temp_file = os.path.join(temp_dir, filename)
+        if not download_file(url, Path(temp_file), options):
+            return None
+
+        # If filter_pattern is used, list matching files based on manifest contents
+        temp_product_path = os.path.join(temp_dir, title)
+        filtered_files = filter_files(Path(temp_file), options.get("filter_pattern"))
+        if filtered_files is None:
+            log.error(f"Failed to parse manifest file for {title}")
+            return None
+        for file in filtered_files:
+            output_file = os.path.join(temp_product_path, file)
+            os.makedirs(os.path.dirname(output_file), exist_ok=True)
+            if not download_file(
+                _get_odata_url(feature["id"], title, str(file)),
+                Path(output_file),
+                options,
+            ):
+                log.error(f"Failed to download {file} from {title}")
+                return None
+
+        # Move downloaded files to output dir
+        if download_full or filtered_files:
+            os.makedirs(path, exist_ok=True)
+            shutil.move(temp_file if download_full else temp_product_path, path)
+
+    return filename if download_full else title
 
 
 def download_features(
@@ -131,6 +223,15 @@ def download_features(
 
 def _get_feature_url(feature) -> str:
     return feature.get("properties").get("services").get("download").get("url")
+
+
+def _get_odata_url(product_id: str, product_name: str, href: str) -> str:
+    """
+    Convert href, describing file location in manifest file, to an OData download URL.
+    """
+    odata_url = "https://download.dataspace.copernicus.eu/odata/v1"
+    path = "/".join([f"Nodes({item})" for item in href.split("/")])
+    return f"{odata_url}/Products({product_id})/Nodes({product_name})/{path}/$value"
 
 
 def _follow_redirect(url: str, session: Session) -> str:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# File intentionally left empty, its purpose is to allow relative imports within the tests folder.

--- a/tests/credentials/__init__.py
+++ b/tests/credentials/__init__.py
@@ -1,0 +1,1 @@
+# File intentionally left empty, its purpose is to allow relative imports within the tests folder.

--- a/tests/credentials/credentials_test.py
+++ b/tests/credentials/credentials_test.py
@@ -1,16 +1,10 @@
 # pyright: reportAttributeAccessIssue=false
 
-import base64
 import datetime
-import json
 from typing import Any
 
-import jwt
 import pytest
 import requests
-from cryptography.hazmat.primitives.asymmetric import rsa
-
-private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
 from cdsetool.credentials import (
     Credentials,
@@ -19,133 +13,13 @@ from cdsetool.credentials import (
     TokenExchangeException,
 )
 
-
-def _mock_openid(requests_mock: Any) -> None:
-    with open("tests/credentials/mock/openid-configuration.json") as f:
-        requests_mock.get(
-            "https://identity.dataspace.copernicus.eu/auth/realms/CDSE/.well-known/openid-configuration",
-            text=f.read(),
-        )
-
-
-def _mock_token(requests_mock: Any) -> None:
-    headers = {"alg": "RS256", "typ": "JWT", "kid": "key-9000"}
-    now = datetime.datetime.now()
-    payload = {
-        "exp": now.timestamp() + 3600,
-        "iat": now.timestamp(),
-        "jti": "bb4d3fab-1a39-442c-9a6f-072a167543c0",
-        "iss": "https://identity.dataspace.copernicus.eu/auth/realms/CDSE",
-        "aud": ["CLOUDFERRO_PUBLIC", "account"],
-        "sub": "bfb3df17-4506-4adf-86ab-9bb9d03f11f1",
-        "typ": "Bearer",
-        "azp": "cdse-public",
-        "session_state": "4adfd9e9-27d2-496d-9c10-bd3a54c8f1a3",
-        "allowed-origins": [
-            "https://localhost:4200",
-            "*",
-            "https://workspace.staging-cdse-data-explorer.apps.staging.intra.cloudferro.com",
-        ],
-        "realm_access": {
-            "roles": [
-                "offline_access",
-                "uma_authorization",
-                "default-roles-cdas",
-                "copernicus-general",
-            ]
-        },
-        "resource_access": {
-            "account": {
-                "roles": ["manage-account", "manage-account-links", "view-profile"]
-            }
-        },
-        "scope": "AUDIENCE_PUBLIC openid email profile user-context",
-        "sid": "03a2986d-ccfa-45e7-8e3a-55982e7e2a6e",
-        "group_membership": [
-            "/access_groups/user_typology/copernicus_general",
-            "/organizations/default-4f0080be-2b79-4837-b6a2-7f10c2b9ee1d/regular_user",
-        ],
-        "email_verified": True,
-        "organizations": ["default-4f0080be-2b79-4837-b6a2-7f10c2b9ee1d"],
-        "name": "User Full Name",
-        "user_context_id": "b9ab6ae1-83b0-433d-828f-e9e06adcc4a2",
-        "context_roles": {},
-        "context_groups": [
-            "/access_groups/user_typology/copernicus_general/",
-            "/organizations/default-4f0080be-2b79-4837-b6a2-7f10c2b9ee1d/regular_user/",
-        ],
-        "preferred_username": "user@example.com",
-        "given_name": "User first name",
-        "user_context": "default-4f0080be-2b79-4837-b6a2-7f10c2b9ee1d",
-        "family_name": "User last name",
-        "email": "user@example.com",
-    }
-
-    response = json.dumps(
-        {
-            "access_token": jwt.encode(
-                payload, private_key, algorithm="RS256", headers=headers
-            ),
-            "expires_in": 600,
-            "refresh_expires_in": 3600,
-            "refresh_token": "check-for-refresh-token-not-implementation-yet",
-            "token_type": "Bearer",
-            "not-before-policy": 0,
-            "session_state": "4adfd9e9-27d2-496d-9c10-bd3a54c8f1a3",
-            "scope": "AUDIENCE_PUBLIC openid email profile user-context",
-        }
-    )
-
-    requests_mock.post(
-        "https://identity.dataspace.copernicus.eu/auth/realms/CDSE/protocol/openid-connect/token",
-        text=response,
-    )
-
-
-def _mock_jwks(mocker: Any) -> None:
-    class MockResponse:
-        def __init__(self, json_data) -> None:
-            self.json_data = json_data
-
-        def __enter__(self) -> "MockResponse":
-            return self
-
-        def read(self) -> bytes:
-            return json.dumps(self.json_data).encode("utf-8")
-
-        def __exit__(
-            self, exc_type: object, exc_value: object, traceback: object
-        ) -> None:
-            pass
-
-    n = private_key.public_key().public_numbers().n
-    e = private_key.public_key().public_numbers().e
-    n = base64.urlsafe_b64encode(
-        n.to_bytes((n.bit_length() + 7) // 8, byteorder="big")
-    ).decode("utf-8")
-    e = base64.urlsafe_b64encode(
-        e.to_bytes((e.bit_length() + 7) // 8, byteorder="big")
-    ).decode("utf-8")
-
-    jwks = {
-        "keys": [
-            {
-                "kid": "key-9000",
-                "kty": "RSA",
-                "alg": "RS256",
-                "use": "sig",
-                "n": n,
-                "e": e,
-            }
-        ]
-    }
-    mocker.patch("urllib.request.urlopen", return_value=MockResponse(jwks))
+from ..mock_auth import mock_jwks, mock_openid, mock_token
 
 
 def test_ensure_tokens(requests_mock: Any, mocker: Any) -> None:
-    _mock_openid(requests_mock)
-    _mock_token(requests_mock)
-    _mock_jwks(mocker)
+    mock_openid(requests_mock)
+    mock_token(requests_mock)
+    mock_jwks(mocker)
 
     credentials = Credentials("username", "password")
     assert credentials._Credentials__access_token is not None
@@ -169,9 +43,9 @@ def test_ensure_tokens(requests_mock: Any, mocker: Any) -> None:
 
 
 def test_read_credentials(requests_mock: Any, mocker: Any) -> None:
-    _mock_openid(requests_mock)
-    _mock_token(requests_mock)
-    _mock_jwks(mocker)
+    mock_openid(requests_mock)
+    mock_token(requests_mock)
+    mock_jwks(mocker)
 
     mocker.patch(
         "netrc.netrc",
@@ -191,15 +65,15 @@ def test_read_credentials(requests_mock: Any, mocker: Any) -> None:
 
 
 def test_refresh_token(requests_mock: Any, mocker: Any) -> None:
-    _mock_openid(requests_mock)
-    _mock_token(requests_mock)
-    _mock_jwks(mocker)
+    mock_openid(requests_mock)
+    mock_token(requests_mock)
+    mock_jwks(mocker)
 
     credentials = Credentials("username", "password")
     assert credentials._Credentials__access_token is not None
     assert credentials._Credentials__refresh_token is not None
 
-    _mock_token(requests_mock)  # mock again to return a new token
+    mock_token(requests_mock)  # mock again to return a new token
 
     prev_access_token = credentials._Credentials__access_token
     credentials._Credentials__access_token_expires = datetime.datetime.now()
@@ -212,9 +86,9 @@ def test_refresh_token(requests_mock: Any, mocker: Any) -> None:
 
 
 def test_get_session(requests_mock: Any, mocker: Any) -> None:
-    _mock_openid(requests_mock)
-    _mock_token(requests_mock)
-    _mock_jwks(mocker)
+    mock_openid(requests_mock)
+    mock_token(requests_mock)
+    mock_jwks(mocker)
 
     credentials = Credentials("username", "password")
     session = credentials.get_session()
@@ -227,9 +101,9 @@ def test_get_session(requests_mock: Any, mocker: Any) -> None:
 
 
 def test_token_exchange(requests_mock: Any, mocker: Any) -> None:
-    _mock_openid(requests_mock)
-    _mock_token(requests_mock)
-    _mock_jwks(mocker)
+    mock_openid(requests_mock)
+    mock_token(requests_mock)
+    mock_jwks(mocker)
 
     credentials = Credentials("myuser123123", "password")
 

--- a/tests/download/__init__.py
+++ b/tests/download/__init__.py
@@ -1,0 +1,1 @@
+# File intentionally left empty, its purpose is to allow relative imports within the tests folder.

--- a/tests/download/download_test.py
+++ b/tests/download/download_test.py
@@ -1,0 +1,265 @@
+"""Tests for CDSETool's download module."""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from cdsetool.credentials import Credentials
+from cdsetool.download import (
+    _get_odata_url,
+    download_feature,
+    download_file,
+    filter_files,
+)
+
+from ..mock_auth import mock_jwks, mock_openid, mock_token
+
+
+def mock_download_file(url: str, path: str, options: Dict[str, Any]) -> bool:
+    """Mock the download_file function to create mock files."""
+    with open(path, "wb") as f:
+        f.write(b"dummy data")
+    return True
+
+
+def test_get_odata_url() -> None:
+    product_id = "a6215824-704b-46d7-a2ec-efea4e468668"
+    product_name = "S2B_MSIL1C_20241209T162609_N0511_R040_T17UPV_20241209T195414.SAFE"
+    href = "path/to/resource.xml"
+    expected_url = (
+        "https://download.dataspace.copernicus.eu/odata/v1/"
+        "Products(a6215824-704b-46d7-a2ec-efea4e468668)/"
+        f"Nodes({product_name})/"
+        "Nodes(path)/Nodes(to)/Nodes(resource.xml)/$value"
+    )
+    assert _get_odata_url(product_id, product_name, href) == expected_url
+
+
+@pytest.mark.parametrize(
+    "manifest_file_path, pattern, expected_files",
+    [
+        (
+            Path("tests/download/mock/sentinel_1/manifest.safe"),
+            "*/calibration-*.xml",
+            [
+                Path(
+                    "annotation/calibration/calibration-s1a-iw-grd-vh-20241217t061735-20241217t061800-057028-07020f-002.xml"
+                ),
+                Path(
+                    "annotation/calibration/calibration-s1a-iw-grd-vv-20241217t061735-20241217t061800-057028-07020f-001.xml"
+                ),
+            ],
+        ),
+        (
+            Path("tests/download/mock/sentinel_2/manifest.safe"),
+            "*TCI.jp2",
+            [
+                Path(
+                    "GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_TCI.jp2"
+                )
+            ],
+        ),
+        (
+            Path("tests/download/mock/sentinel_3/xfdumanifest.xml"),
+            "*Oa02_reflectance.nc",
+            [Path("Oa02_reflectance.nc")],
+        ),
+    ],
+)
+def test_filter_files(
+    manifest_file_path: Path, pattern: str, expected_files: List[str]
+) -> None:
+    filtered_files = filter_files(manifest_file_path, pattern)
+    assert filtered_files == expected_files
+
+
+def test_filter_files_with_exclude() -> None:
+    manifest_file_path = Path("tests/download/mock/sentinel_2/manifest.safe")
+    filtered_files = filter_files(manifest_file_path, "*.jp2", exclude=True)
+    assert filtered_files == [
+        Path("MTD_MSIL1C.xml"),
+        Path("INSPIRE.xml"),
+        Path("HTML/UserProduct_index.html"),
+        Path("HTML/UserProduct_index.xsl"),
+        Path("DATASTRIP/DS_2BPS_20241209T195414_S20241209T162603/MTD_DS.xml"),
+        Path(
+            "DATASTRIP/DS_2BPS_20241209T195414_S20241209T162603/QI_DATA/FORMAT_CORRECTNESS.xml"
+        ),
+        Path(
+            "DATASTRIP/DS_2BPS_20241209T195414_S20241209T162603/QI_DATA/GENERAL_QUALITY.xml"
+        ),
+        Path(
+            "DATASTRIP/DS_2BPS_20241209T195414_S20241209T162603/QI_DATA/GEOMETRIC_QUALITY.xml"
+        ),
+        Path(
+            "DATASTRIP/DS_2BPS_20241209T195414_S20241209T162603/QI_DATA/RADIOMETRIC_QUALITY.xml"
+        ),
+        Path(
+            "DATASTRIP/DS_2BPS_20241209T195414_S20241209T162603/QI_DATA/SENSOR_QUALITY.xml"
+        ),
+        Path("GRANULE/L1C_T17UPV_A040535_20241209T162603/AUX_DATA/AUX_CAMSFO"),
+        Path("GRANULE/L1C_T17UPV_A040535_20241209T162603/AUX_DATA/AUX_ECMWFT"),
+        Path("GRANULE/L1C_T17UPV_A040535_20241209T162603/MTD_TL.xml"),
+        Path(
+            "GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/FORMAT_CORRECTNESS.xml"
+        ),
+        Path("GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/GENERAL_QUALITY.xml"),
+        Path(
+            "GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/GEOMETRIC_QUALITY.xml"
+        ),
+        Path("GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/SENSOR_QUALITY.xml"),
+    ]
+
+
+def test_filter_files_no_match() -> None:
+    manifest_file_path = Path("tests/download/mock/sentinel_2/manifest.safe")
+    filtered_files = filter_files(manifest_file_path, "Oa1*.nc")
+    assert not filtered_files
+
+
+def test_filter_files_broken_manifest() -> None:
+    manifest_file_path = Path("tests/download/mock/sentinel_2/broken_manifest.safe")
+    filtered_files = filter_files(manifest_file_path, "*TCI.jp2")
+    assert filtered_files is None
+
+
+def test_download_file_success(requests_mock: Any, mocker: Any, tmp_path: Path) -> None:
+    mock_openid(requests_mock)
+    mock_token(requests_mock)
+    mock_jwks(mocker)
+
+    mock_url = "http://example.com/file"
+    mocker.patch("cdsetool.download._follow_redirect", return_value=mock_url)
+    content = b"data" * 5
+    requests_mock.get(
+        mock_url, status_code=200, headers={"Content-Length": "100"}, content=content
+    )
+    mock_file = tmp_path / "mock_file"
+
+    result = download_file(
+        mock_url, mock_file, {"credentials": Credentials("usr", "pwd")}
+    )
+
+    assert result is True
+
+    # Check that file was written correctly
+    with open(mock_file, "rb") as f:
+        file_content = f.read()
+    assert file_content == content
+
+
+def test_download_file_failure(requests_mock: Any, mocker: Any, tmp_path: Path) -> None:
+    mock_openid(requests_mock)
+    mock_token(requests_mock)
+    mock_jwks(mocker)
+
+    mock_url = "http://example.com/file"
+    mocker.patch("cdsetool.download._follow_redirect", return_value=mock_url)
+    requests_mock.get(mock_url, status_code=404, headers={"Content-Length": "100"})
+    mock_file = tmp_path / "mock_file"
+    mocker.patch("time.sleep", return_value=None)  # Avoid retry delay
+
+    result = download_file(
+        mock_url, mock_file, {"credentials": Credentials("usr", "pwd")}
+    )
+    assert result is False
+
+
+def test_download_feature(mocker: Any, tmp_path: Path) -> None:
+    title = "S2B_MSIL1C_20241209T162609_N0511_R040_T17UPV_20241209T195414.SAFE"
+    mock_feature = {
+        "id": "a6215824-704b-46d7-a2ec-efea4e468668",
+        "properties": {
+            "title": title,
+            "collection": "SENTINEL-2",
+            "services": {"download": {"url": "http://example.com"}},
+        },
+    }
+    mocker.patch("cdsetool.download.download_file", mock_download_file)
+
+    final_dir = str(tmp_path / "test_download_feature")
+    filename = download_feature(mock_feature, final_dir)
+    assert filename == f"{title}.zip"
+    assert os.path.exists(os.path.join(final_dir, f"{title}.zip"))
+
+
+def test_download_feature_failure(mocker: Any, tmp_path: Path) -> None:
+    title = "S2B_MSIL1C_20241209T162609_N0511_R040_T17UPV_20241209T195414.SAFE"
+    mock_feature = {
+        "id": "a6215824-704b-46d7-a2ec-efea4e468668",
+        "properties": {
+            "title": title,
+            "collection": "SENTINEL-2",
+            "services": {"download": {"url": "http://example.com"}},
+        },
+    }
+    mocker.patch(
+        "cdsetool.download.download_file", side_effect=lambda url, path, options: None
+    )
+
+    final_dir = str(tmp_path / "test_download_feature_failure")
+    filename = download_feature(mock_feature, final_dir)
+    assert filename is None
+
+
+def test_download_feature_with_filter(mocker: Any, tmp_path: Path) -> None:
+    options = {"filter_pattern": "*.jp2"}
+    title = "S2B_MSIL1C_20241209T162609_N0511_R040_T17UPV_20241209T195414.SAFE"
+    mock_feature = {
+        "id": "a6215824-704b-46d7-a2ec-efea4e468668",
+        "properties": {"title": title, "collection": "SENTINEL-2"},
+    }
+    mocker.patch(
+        "cdsetool.download.filter_files",
+        return_value=[Path("./GRANULE/file1.jp2"), Path("./GRANULE/file2.jp2")],
+    )
+    mocker.patch("cdsetool.download.download_file", mock_download_file)
+
+    final_dir = str(tmp_path / "test_download_feature_with_filter")
+    product_name = download_feature(mock_feature, final_dir, options)
+    assert product_name == mock_feature["properties"]["title"]
+    assert os.path.exists(os.path.join(final_dir, title, "GRANULE", "file1.jp2"))
+    assert os.path.exists(os.path.join(final_dir, title, "GRANULE", "file2.jp2"))
+
+
+def test_download_feature_with_filter_failure(mocker: Any, tmp_path: Path) -> None:
+    options = {"filter_pattern": "*.jp2"}
+    mock_feature = {
+        "id": "a6215824-704b-46d7-a2ec-efea4e468668",
+        "properties": {
+            "title": "S2B_MSIL1C_20241209T162609_N0511_R040_T17UPV_20241209T195414.SAFE",
+            "collection": "SENTINEL-2",
+        },
+    }
+    mocker.patch(
+        "cdsetool.download.filter_files",
+        return_value=["./GRANULE/file1.jp2", "./GRANULE/file2.jp2"],
+    )
+    mocker.patch(
+        "cdsetool.download.download_file", side_effect=lambda url, path, options: None
+    )
+
+    final_dir = str(tmp_path / "test_download_feature_with_filter_failure")
+    product_name = download_feature(mock_feature, final_dir, options)
+    assert product_name is None
+
+
+def test_download_feature_with_filter_unsupported_coll(
+    caplog: Any, tmp_path: Path
+) -> None:
+    options = {"logger": logging.getLogger(__name__), "filter_pattern": "*MTL.txt"}
+    mock_feature = {
+        "id": "a6215824-704b-46d7-a2ec-efea4e468668",
+        "properties": {"title": "L8XXX", "collection": "Landsat8"},
+    }
+
+    final_dir = str(tmp_path / "test_download_feature_with_filter_unsupported_coll")
+    product_name = download_feature(mock_feature, final_dir, options)
+    assert product_name is None
+    assert (
+        "No support for downloading individual files in "
+        f"{mock_feature['properties']['collection']} products"
+    ) in caplog.text

--- a/tests/download/mock/sentinel_1/manifest.safe
+++ b/tests/download/mock/sentinel_1/manifest.safe
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xfdu:XFDU xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xmlns:xfdu="urn:ccsds:schema:xfdu:1" xmlns:safe="http://www.esa.int/safe/sentinel-1.0" xmlns:s1="http://www.esa.int/safe/sentinel-1.0/sentinel-1" xmlns:s1sar="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar" xmlns:s1sarl1="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-1" xmlns:s1sarl2="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-2" xmlns:gx="http://www.google.com/kml/ext/2.2" version="esa/safe/sentinel-1.0/sentinel-1/sar/level-1/grd/standard/iwdp">
+  <informationPackageMap>
+    <xfdu:contentUnit unitType="SAFE Archive Information Package" textInfo="Sentinel-1 IW Level-1 GRD Product" dmdID="acquisitionPeriod platform generalProductInformation measurementOrbitReference measurementFrameSet" pdiID="processing">
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiwgrdvh20241217t06173520241217t06180005702807020f002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiwgrdvh20241217t06173520241217t06180005702807020f002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1RfiSchema">
+        <dataObjectPointer dataObjectID="rfis1aiwgrdvh20241217t06173520241217t06180005702807020f002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiwgrdvh20241217t06173520241217t06180005702807020f002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiwgrdvv20241217t06173520241217t06180005702807020f001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiwgrdvv20241217t06173520241217t06180005702807020f001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1RfiSchema">
+        <dataObjectPointer dataObjectID="rfis1aiwgrdvv20241217t06173520241217t06180005702807020f001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiwgrdvv20241217t06173520241217t06180005702807020f001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1MapOverlaySchema">
+        <dataObjectPointer dataObjectID="mapoverlay"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductPreviewSchema">
+        <dataObjectPointer dataObjectID="productpreview"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiwgrdvh20241217t06173520241217t06180005702807020f002Annotation noises1aiwgrdvh20241217t06173520241217t06180005702807020f002Annotation rfis1aiwgrdvh20241217t06173520241217t06180005702807020f002Annotation calibrations1aiwgrdvh20241217t06173520241217t06180005702807020f002Annotation ">
+        <dataObjectPointer dataObjectID="s1aiwgrdvh20241217t06173520241217t06180005702807020f002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiwgrdvv20241217t06173520241217t06180005702807020f001Annotation noises1aiwgrdvv20241217t06173520241217t06180005702807020f001Annotation rfis1aiwgrdvv20241217t06173520241217t06180005702807020f001Annotation calibrations1aiwgrdvv20241217t06173520241217t06180005702807020f001Annotation ">
+        <dataObjectPointer dataObjectID="s1aiwgrdvv20241217t06173520241217t06180005702807020f001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1QuickLookSchema">
+        <dataObjectPointer dataObjectID="quicklook"/>
+      </xfdu:contentUnit>
+    </xfdu:contentUnit>
+  </informationPackageMap>
+  <metadataSection>
+    <metadataObject ID="products1aiwgrdvh20241217t06173520241217t06180005702807020f002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiwgrdvh20241217t06173520241217t06180005702807020f002"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiwgrdvh20241217t06173520241217t06180005702807020f002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiwgrdvh20241217t06173520241217t06180005702807020f002"/>
+    </metadataObject>
+    <metadataObject ID="rfis1aiwgrdvh20241217t06173520241217t06180005702807020f002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="rfis1aiwgrdvh20241217t06173520241217t06180005702807020f002"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiwgrdvh20241217t06173520241217t06180005702807020f002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiwgrdvh20241217t06173520241217t06180005702807020f002"/>
+    </metadataObject>
+    <metadataObject ID="products1aiwgrdvv20241217t06173520241217t06180005702807020f001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiwgrdvv20241217t06173520241217t06180005702807020f001"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiwgrdvv20241217t06173520241217t06180005702807020f001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiwgrdvv20241217t06173520241217t06180005702807020f001"/>
+    </metadataObject>
+    <metadataObject ID="rfis1aiwgrdvv20241217t06173520241217t06180005702807020f001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="rfis1aiwgrdvv20241217t06173520241217t06180005702807020f001"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiwgrdvv20241217t06173520241217t06180005702807020f001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiwgrdvv20241217t06173520241217t06180005702807020f001"/>
+    </metadataObject>
+    <metadataObject ID="mapoverlayAnnotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="mapoverlay"/>
+    </metadataObject>
+    <metadataObject ID="productpreviewAnnotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="productpreview"/>
+    </metadataObject>
+    <metadataObject ID="processing" classification="PROVENANCE" category="PDI">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Processing">
+        <xmlData>
+          <safe:processing name="GRD Post Processing" start="2024-12-17T06:51:35.941104" stop="2024-12-17T07:00:07.000000">
+            <safe:facility country="Italy" name="Copernicus Ground Segment" organisation="ESA" site="Production Service-SERCO">
+              <safe:software name="Sentinel-1 IPF" version="003.90"/>
+            </safe:facility>
+            <safe:resource name="S1A_IW_SL1__1_DV_20241217T061731_20241217T061804_057028_07020F_D759.SAFE" role="Level-1 Intermediate SLC Product">
+              <safe:processing name="SLC Processing" start="2024-12-17T06:54:09.000000" stop="2024-12-17T06:58:50.000000" xmlns="http://www.esa.int/safe/sentinel-1.0">
+                <safe:facility country="Italy" name="Copernicus Ground Segment" organisation="ESA" site="Production Service-SERCO">
+                  <safe:software name="Sentinel-1 IPF" version="003.90"/>
+                </safe:facility>
+                <safe:resource name="/data/CDP/production//2210160/S1A_AUX_PP1_V20190228T092500_G20241125T134138.SAFE" role="AUX_PP1"/>
+                <safe:resource name="/data/CDP/production//2210160/S1A_AUX_CAL_V20190228T092500_G20240327T102320.SAFE" role="AUX_CAL"/>
+                <safe:resource name="/data/CDP/production//2210160/S1A_AUX_INS_V20190228T092500_G20211103T111906.SAFE" role="AUX_INS"/>
+                <safe:resource name="/data/CDP/production//2210160/S1A_OPER_AUX_PREORB_OPOD_20241217T062053_V20241217T054013_20241217T121513.EOF" role="AUX_PRE"/>
+                <safe:resource name="/data/CDP/production//2210160/S1A_IW_RAW__0ADV_20241217T060911_20241217T062143_057028_07020F_1671.SAFE" role="Level-0 Annotation Product"/>
+                <safe:resource name="/data/CDP/production//2210160/S1A_IW_RAW__0CDV_20241217T060911_20241217T062143_057028_07020F_200A.SAFE" role="Level-0 Calibration Product"/>
+                <safe:resource name="/data/CDP/production//2210160/S1A_IW_RAW__0NDV_20241217T060911_20241217T062143_057028_07020F_2BD3.SAFE" role="Level-0 Noise Product"/>
+                <safe:resource name="/data/CDP/production//2210160/S1A_IW_RAW__0SDV_20241217T061731_20241217T061804_057028_07020F_A1DD.SAFE" role="Level-0 Product">
+                  <safe:processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Generation of Sentinel-1 L0 SAR Product, dual polarisation" start="2024-12-17T06:37:23.958930" stop="2024-12-17T06:37:24.044202">
+                    <safe:facility country="Italy" name="S1A-PS" organisation="ESA" site="S1 Production Service-SERCO">
+                      <safe:software name="" version=""/>
+                    </safe:facility>
+                    <safe:resource name="S-1 Core PDGS S-1 Level-0 Product Format Specifications S1PD.SP.00110.ASTR" role="Applicable Document"/>
+                    <safe:resource name="Sentinel-1 SAR Space Packet Protocol Data Unit S1-IF-ASD-PL-0007" role="Applicable Document" version="13.0"/>
+                    <safe:resource name="Unknown" role="Raw Data">
+                      <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Generation of Sentinel-1 SAR Slice L0 product single polarisation" start="2024-12-17T06:32:40.486125" stop="2024-12-17T06:32:41.115335">
+                        <resource name="S-1 Core PDGS S-1 Level-0 Product Format Specifications S1PD.SP.00110.ASTR" role="Applicable Document">
+                           </resource>
+                        <resource name="Sentinel-1 SAR Space Packet Protocol Data Unit S1-IF-ASD-PL-0007" version="13.0" role="Applicable Document">
+                           </resource>
+                        <resource name="Downlinked Stream" role="Raw Data">
+                          <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Raw Data Downlink Channel1 1" start="2024-12-17T06:19:21.524085" stop="2024-12-17T06:20:06.761550">
+                              </processing>
+                        </resource>
+                      </processing>
+                    </safe:resource>
+                    <safe:resource name="Unknown" role="Raw Data">
+                      <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Generation of Sentinel-1 SAR Slice L0 product single polarisation" start="2024-12-17T06:35:40.358301" stop="2024-12-17T06:35:40.979460">
+                        <resource name="S-1 Core PDGS S-1 Level-0 Product Format Specifications S1PD.SP.00110.ASTR" role="Applicable Document">
+                           </resource>
+                        <resource name="Sentinel-1 SAR Space Packet Protocol Data Unit S1-IF-ASD-PL-0007" version="13.0" role="Applicable Document">
+                           </resource>
+                        <resource name="Downlinked Stream" role="Raw Data">
+                          <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Raw Data Downlink Channel2 2" start="2024-12-17T06:19:41.976261" stop="2024-12-17T06:20:11.922194">
+                              </processing>
+                        </resource>
+                      </processing>
+                    </safe:resource>
+                  </safe:processing>
+                </safe:resource>
+                <safe:resource name="Sentinel-1 Product Definition (S1-RS-MDA-52-7440) release 2/7" role="product definition"/>
+                <safe:resource name="Sentinel-1 Product Specification (S1-RS-MDA-52-7441) release 3/14" role="product specification"/>
+              </safe:processing>
+            </safe:resource>
+          </safe:processing>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="platform" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Platform Description">
+        <xmlData>
+          <safe:platform>
+            <safe:nssdcIdentifier>2014-016A</safe:nssdcIdentifier>
+            <safe:familyName>SENTINEL-1</safe:familyName>
+            <safe:number>A</safe:number>
+            <safe:instrument>
+              <safe:familyName abbreviation="SAR">Synthetic Aperture Radar</safe:familyName>
+              <safe:extension>
+                <s1sarl1:instrumentMode>
+                  <s1sarl1:mode>IW</s1sarl1:mode>
+                  <s1sarl1:swath>IW</s1sarl1:swath>
+                </s1sarl1:instrumentMode>
+              </safe:extension>
+            </safe:instrument>
+          </safe:platform>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="measurementOrbitReference" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Orbit Reference">
+        <xmlData>
+          <safe:orbitReference>
+            <safe:orbitNumber type="start">57028</safe:orbitNumber>
+            <safe:orbitNumber type="stop">57028</safe:orbitNumber>
+            <safe:relativeOrbitNumber type="start">81</safe:relativeOrbitNumber>
+            <safe:relativeOrbitNumber type="stop">81</safe:relativeOrbitNumber>
+            <safe:cycleNumber>340</safe:cycleNumber>
+            <safe:phaseIdentifier>1</safe:phaseIdentifier>
+            <safe:extension>
+              <s1:orbitProperties>
+                <s1:pass>DESCENDING</s1:pass>
+                <s1:ascendingNodeTime>2024-12-17T05:40:13.187705</s1:ascendingNodeTime>
+              </s1:orbitProperties>
+            </safe:extension>
+          </safe:orbitReference>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="generalProductInformation" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="General Product Information">
+        <xmlData>
+          <s1sarl1:standAloneProductInformation>
+            <s1sarl1:instrumentConfigurationID>7</s1sarl1:instrumentConfigurationID>
+            <s1sarl1:missionDataTakeID>459279</s1sarl1:missionDataTakeID>
+            <s1sarl1:transmitterReceiverPolarisation>VV</s1sarl1:transmitterReceiverPolarisation>
+            <s1sarl1:transmitterReceiverPolarisation>VH</s1sarl1:transmitterReceiverPolarisation>
+            <s1sarl1:productClass>S</s1sarl1:productClass>
+            <s1sarl1:productClassDescription>SAR Standard L1 Product</s1sarl1:productClassDescription>
+            <s1sarl1:productComposition>Slice</s1sarl1:productComposition>
+            <s1sarl1:productType>GRD</s1sarl1:productType>
+            <s1sarl1:productTimelinessCategory>NRT-3h</s1sarl1:productTimelinessCategory>
+            <s1sarl1:sliceProductFlag>true</s1sarl1:sliceProductFlag>
+            <s1sarl1:segmentStartTime>2024-12-17T06:09:11.775902</s1sarl1:segmentStartTime>
+            <s1sarl1:sliceNumber>21</s1sarl1:sliceNumber>
+            <s1sarl1:totalSlices>30</s1sarl1:totalSlices>
+          </s1sarl1:standAloneProductInformation>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="acquisitionPeriod" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Acquisition Period">
+        <xmlData>
+          <safe:acquisitionPeriod>
+            <safe:startTime>2024-12-17T06:17:35.476248</safe:startTime>
+            <safe:stopTime>2024-12-17T06:18:00.475440</safe:stopTime>
+            <safe:extension>
+              <s1:timeANX>
+                <s1:startTimeANX>2.242288e+06</s1:startTimeANX>
+                <s1:stopTimeANX>2.267288e+06</s1:stopTimeANX>
+              </s1:timeANX>
+            </safe:extension>
+          </safe:acquisitionPeriod>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="measurementFrameSet" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Frame Set">
+        <xmlData>
+          <safe:frameSet>
+            <safe:frame>
+              <safe:footPrint srsName="http://www.opengis.net/gml/srs/epsg.xml#4326">
+                <gml:coordinates>42.366711,-1.164012 42.775124,-4.343804 44.273342,-4.011340 43.865166,-0.752081</gml:coordinates>
+              </safe:footPrint>
+            </safe:frame>
+          </safe:frameSet>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="s1Level1ProductSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-product.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1NoiseSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-noise.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1RfiSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-rfi.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1CalibrationSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-calibration.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1ObjectTypesSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-object-types.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1MeasurementSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="SDF" locatorType="URL" href="./support/s1-level-1-measurement.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1ProductPreviewSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-product-preview.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1QuickLookSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-quicklook.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1MapOverlaySchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-map-overlay.xsd"/>
+    </metadataObject>
+  </metadataSection>
+  <dataObjectSection>
+    <dataObject ID="products1aiwgrdvh20241217t06173520241217t06180005702807020f002" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="1888864">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw-grd-vh-20241217t061735-20241217t061800-057028-07020f-002.xml"/>
+        <checksum checksumName="MD5">5b30ed5fdd5c443779924148cc0ab233</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiwgrdvh20241217t06173520241217t06180005702807020f002" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="422080">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw-grd-vh-20241217t061735-20241217t061800-057028-07020f-002.xml"/>
+        <checksum checksumName="MD5">97bbba6752ff6c8481c5359b2dad036f</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="rfis1aiwgrdvh20241217t06173520241217t06180005702807020f002" repID="s1Level1RfiSchema">
+      <byteStream mimeType="text/xml" size="20231">
+        <fileLocation locatorType="URL" href="./annotation/rfi/rfi-s1a-iw-grd-vh-20241217t061735-20241217t061800-057028-07020f-002.xml"/>
+        <checksum checksumName="MD5">de1b98b98001255ef4301acfa9ddaf71</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiwgrdvh20241217t06173520241217t06180005702807020f002" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="1041457">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw-grd-vh-20241217t061735-20241217t061800-057028-07020f-002.xml"/>
+        <checksum checksumName="MD5">7861e6ec3cd64bcfece1441f390ff314</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiwgrdvv20241217t06173520241217t06180005702807020f001" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="1888897">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw-grd-vv-20241217t061735-20241217t061800-057028-07020f-001.xml"/>
+        <checksum checksumName="MD5">1985a1e903bc8a6137dc9d88a4ced035</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiwgrdvv20241217t06173520241217t06180005702807020f001" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="422080">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw-grd-vv-20241217t061735-20241217t061800-057028-07020f-001.xml"/>
+        <checksum checksumName="MD5">f828087c6ef5f41f8f33a633ad8ddeb6</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="rfis1aiwgrdvv20241217t06173520241217t06180005702807020f001" repID="s1Level1RfiSchema">
+      <byteStream mimeType="text/xml" size="20231">
+        <fileLocation locatorType="URL" href="./annotation/rfi/rfi-s1a-iw-grd-vv-20241217t061735-20241217t061800-057028-07020f-001.xml"/>
+        <checksum checksumName="MD5">02c0dda3f8e409a15e92f9635625316b</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiwgrdvv20241217t06173520241217t06180005702807020f001" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="1041457">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw-grd-vv-20241217t061735-20241217t061800-057028-07020f-001.xml"/>
+        <checksum checksumName="MD5">42128e0689c0d32be00c71953adccf0e</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="mapoverlay" repID="s1Level1MapOverlaySchema">
+      <byteStream mimeType="text/xml" size="1018">
+        <fileLocation locatorType="URL" href="./preview/map-overlay.kml"/>
+        <checksum checksumName="MD5">abca46e8ad0eb8cee9a853963a4cc624</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="productpreview" repID="s1Level1ProductPreviewSchema">
+      <byteStream mimeType="text/xml" size="3673">
+        <fileLocation locatorType="URL" href="./preview/product-preview.html"/>
+        <checksum checksumName="MD5">ccc01e1335dcaedbfbea083dccc0a140</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiwgrdvh20241217t06173520241217t06180005702807020f002" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="883926956">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw-grd-vh-20241217t061735-20241217t061800-057028-07020f-002.tiff"/>
+        <checksum checksumName="MD5">c6ab33190822b1151862d7a86433b896</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiwgrdvv20241217t06173520241217t06180005702807020f001" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="883926956">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw-grd-vv-20241217t061735-20241217t061800-057028-07020f-001.tiff"/>
+        <checksum checksumName="MD5">f1d13a5bbd57c466f2192fe7246d4472</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="quicklook" repID="s1Level1QuickLookSchema">
+      <byteStream mimeType="application/octet-stream" size="281171">
+        <fileLocation locatorType="URL" href="./preview/quick-look.png"/>
+        <checksum checksumName="MD5">7a7f2cba6bec280ff36c63b7dfa95697</checksum>
+      </byteStream>
+    </dataObject>
+  </dataObjectSection>
+</xfdu:XFDU>

--- a/tests/download/mock/sentinel_2/broken_manifest.safe
+++ b/tests/download/mock/sentinel_2/broken_manifest.safe
@@ -1,0 +1,8 @@
+<dataObjectSection>
+    <dataObject ID="S2_Level-1C_Product_Metadata">
+        <byteStream mimeType="text/xml" size="45353">
+            <fileLocation locatorType="URL"/>
+            <checksum checksumName="SHA3-256">91CB5B925086749536F310AC7F5E0F2F892CE36FBAA85D6DF2E696EAA64B8400</checksum>
+        </byteStream>
+    </dataObject>
+</dataObjectSection>

--- a/tests/download/mock/sentinel_2/manifest.safe
+++ b/tests/download/mock/sentinel_2/manifest.safe
@@ -1,0 +1,567 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xfdu:XFDU xmlns:gml="http://www.opengis.net/gml" xmlns:safe="http://www.esa.int/safe/sentinel/1.1" xmlns:xfdu="urn:ccsds:schema:xfdu:1" version="esa/safe/sentinel/1.1/sentinel-2/msi/archive_l1c_user_product">	<!-- ===================================================================      INFORMATION PACKAGE MAP SECTION      =================================================================== -->	<informationPackageMap>		<xfdu:contentUnit dmdID="acquisitionPeriod platform" pdiID="processing" textInfo="SENTINEL-2 MSI Level-1C User Product" unitType="Product_Level-1C">
+            <xfdu:contentUnit ID="Product_Metadata_Level-1C" unitType="Metadata Unit">
+                <dataObjectPointer dataObjectID="S2_Level-1C_Product_Metadata"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit ID="INSPIRE_Metadata_Unit" unitType="Metadata Unit">
+                <dataObjectPointer dataObjectID="INSPIRE_Metadata"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit ID="HTML" textInfo="HTML container">
+                <xfdu:contentUnit ID="HTML_Presentation_Unit" unitType="Data Unit">
+                    <dataObjectPointer dataObjectID="HTML_Presentation"/>
+                </xfdu:contentUnit>
+                <xfdu:contentUnit ID="HTML_Stylesheet_Unit" unitType="Data Unit">
+                    <dataObjectPointer dataObjectID="HTML_Presentation_Stylesheet"/>
+                </xfdu:contentUnit>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit ID="Datastrips" textInfo="Datastrips Container">
+                <xfdu:contentUnit ID="Datastrip1" textInfo="Datastrip Container">
+                    <xfdu:contentUnit ID="S2_Level-1C_Datastrip1_Metadata_Unit" unitType="Metadata Unit"> <dataObjectPointer dataObjectID="S2_Level-1C_Datastrip1_Metadata"/>
+                    </xfdu:contentUnit>
+                    <xfdu:contentUnit ID="QI_DATA_Datastrip1" textInfo="Quality Control Container">
+                        <xfdu:contentUnit ID="Format_OLQC_Report_Datastrip1_InformationUnit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="Format_OLQC_Report_Datastrip1_InformationData"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="General_OLQC_Report_Datastrip1_InformationUnit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="General_OLQC_Report_Datastrip1_InformationData"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="Geometric_OLQC_Report_Datastrip1_InformationUnit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="Geometric_OLQC_Report_Datastrip1_InformationData"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="Radiometric_OLQC_Report_Datastrip1_InformationUnit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="Radiometric_OLQC_Report_Datastrip1_InformationData"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="Sensor_OLQC_Report_Datastrip1_InformationUnit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="Sensor_OLQC_Report_Datastrip1_InformationData"/>
+                        </xfdu:contentUnit>
+                    </xfdu:contentUnit>
+                </xfdu:contentUnit>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit ID="Tiles" textInfo="Tiles Container">
+                <xfdu:contentUnit ID="Tile1" textInfo="Tile Container">
+                    <xfdu:contentUnit ID="AUX_DATA_GranuleTile1" textInfo="Auxiliary Container">
+                        <xfdu:contentUnit ID="CAMS_Tile1_Unit" textInfo="Auxiliary Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="CAMS_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="ECMWF_Tile1_Unit" textInfo="Auxiliary Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="ECMWF_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                    </xfdu:contentUnit>
+                    <xfdu:contentUnit ID="IMG_Data_Tile1" textInfo="Image Data Container">
+                        <xfdu:contentUnit ID="IMG_DATA_Band_60m_1_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_60m_1_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_10m_1_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_10m_1_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_10m_2_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_10m_2_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_10m_3_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_10m_3_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_20m_1_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_20m_1_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_20m_2_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_20m_2_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_20m_3_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_20m_3_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_10m_4_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_10m_4_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_60m_2_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_60m_2_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_60m_3_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_60m_3_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_20m_5_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_20m_5_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_20m_6_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_20m_6_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_20m_4_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_20m_4_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="IMG_DATA_Band_TCI_Tile1_Unit" textInfo="Image Data container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="IMG_DATA_Band_TCI_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                    </xfdu:contentUnit>
+                    <xfdu:contentUnit ID="S2_Level-1C_Tile1_Metadata_Unit" unitType="Metadata Unit"> <dataObjectPointer dataObjectID="S2_Level-1C_Tile1_Metadata"/>
+                    </xfdu:contentUnit>
+                    <xfdu:contentUnit ID="QI_DATA_Tile1" textInfo="Quality Control Container">
+                        <xfdu:contentUnit ID="Format_OLQC_Report_Tile1_InformationUnit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="Format_OLQC_Report_Tile1_InformationData"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="General_OLQC_Report_Tile1_InformationUnit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="General_OLQC_Report_Tile1_InformationData"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="Geometric_OLQC_Report_Tile1_InformationUnit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="Geometric_OLQC_Report_Tile1_InformationData"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="ClassiPixelsMask_Band_00m_0_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="ClassiPixelsMask_Band_00m_0_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_60m_1_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_60m_1_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_10m_1_1_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_10m_1_1_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_10m_2_2_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_10m_2_2_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_10m_3_3_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_10m_3_3_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_20m_1_4_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_20m_1_4_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_20m_2_5_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_20m_2_5_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_20m_3_6_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_20m_3_6_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_10m_4_7_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_10m_4_7_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_60m_2_8_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_60m_2_8_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_60m_3_9_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_60m_3_9_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_20m_5_10_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_20m_5_10_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_20m_6_11_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_20m_6_11_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="DetectorFootprintMask_Band_20m_4_12_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="DetectorFootprintMask_Band_20m_4_12_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_60m_1_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_60m_1_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_10m_1_1_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_10m_1_1_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_10m_2_2_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_10m_2_2_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_10m_3_3_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_10m_3_3_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_20m_1_4_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_20m_1_4_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_20m_2_5_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_20m_2_5_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_20m_3_6_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_20m_3_6_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_10m_4_7_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_10m_4_7_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_60m_2_8_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_60m_2_8_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_60m_3_9_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_60m_3_9_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_20m_5_10_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_20m_5_10_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_20m_6_11_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_20m_6_11_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="QualitPixelsMask_Band_20m_4_12_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="QualitPixelsMask_Band_20m_4_12_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="Sensor_OLQC_Report_Tile1_InformationUnit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="Sensor_OLQC_Report_Tile1_InformationData"/>
+                        </xfdu:contentUnit>
+                        <xfdu:contentUnit ID="Preview_0_Tile1_Unit" textInfo="Quality Control Container" unitType="Measurement Data Unit">
+                            <dataObjectPointer dataObjectID="Preview_0_Tile1_Data"/>
+                        </xfdu:contentUnit>
+                    </xfdu:contentUnit>
+                </xfdu:contentUnit>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit ID="AuxData" textInfo="Auxiliary Data container"/>
+        </xfdu:contentUnit>
+    </informationPackageMap>
+    <!-- ===================================================================      METADATA OBJECT SECTION      =================================================================== -->	<metadataSection>		<!-- PRODUCT GENERAL METADATA ======================================= -->		<!-- Acquisition Period -->		<metadataObject ID="acquisitionPeriod" category="DMD" classification="DESCRIPTION">			<metadataWrap mimeType="text/xml" textInfo="Acquisition Period" vocabularyName="Sentinel-SAFE">				<xmlData>					<safe:acquisitionPeriod>						<safe:startTime>2024-12-09T16:26:09.024Z</safe:startTime>					</safe:acquisitionPeriod>				</xmlData>			</metadataWrap>		</metadataObject>		<!-- Orbit Reference -->		<metadataObject ID="measurementOrbitReference" category="DMD" classification="DESCRIPTION">			<metadataWrap mimeType="text/xml" textInfo="Orbit Reference" vocabularyName="Sentinel-SAFE">				<xmlData>					<safe:orbitReference>						<safe:orbitNumber groundTrackDirection="descending" type="start">040535</safe:orbitNumber>						<safe:relativeOrbitNumber type="start">040</safe:relativeOrbitNumber>					</safe:orbitReference>				</xmlData>			</metadataWrap>		</metadataObject>		<!-- Platform description -->		<metadataObject ID="platform" category="DMD" classification="DESCRIPTION">			<metadataWrap mimeType="text/xml" textInfo="Platform Description" vocabularyName="Sentinel-SAFE">				<xmlData>					<safe:platform>						<safe:nssdcIdentifier>2015-000A</safe:nssdcIdentifier>						<safe:familyName>SENTINEL</safe:familyName>						<safe:number>2B</safe:number>						<safe:instrument>							<safe:familyName abbreviation="MSI">Multi-Spectral Instrument</safe:familyName>						</safe:instrument>					</safe:platform>				</xmlData>			</metadataWrap>		</metadataObject>		<!-- Processing -->		<metadataObject ID="processing" category="PDI" classification="PROVENANCE">			<metadataWrap mimeType="text/xml" textInfo="Processing" vocabularyName="Sentinel-SAFE">				<xmlData>					<safe:processing xmlns="http://www.esa.int/safe/sentinel/1.1" name="Generation of Level-1C User Product" start="2024-12-09T19:54:14.000000Z">					</safe:processing>				</xmlData>			</metadataWrap>		</metadataObject>		<!-- Measurement Frame set -->		<metadataObject ID="measurementFrameSet" category="DMD" classification="DESCRIPTION">			<metadataWrap mimeType="text/xml" textInfo="Frame Set" vocabularyName="Sentinel-SAFE">				<xmlData>					<safe:frameSet>						<safe:footPrint srsName="http://www.opengis.net/gml/srs/epsg.xml#4326">							<gml:coordinates>54.138373318280884 -79.46929874363425 54.10530483528773 -77.79073991512661 53.119880621881606 -77.86467963079592 53.15178549855093 -79.50462041848775 54.138373318280884 -79.46929874363425 </gml:coordinates>						</safe:footPrint>					</safe:frameSet>				</xmlData>			</metadataWrap>		</metadataObject>
+        <metadataObject ID="S2_Level-1C_Product_Metadata_Information" category="DMD" classification="DESCRIPTION">
+            <dataObjectPointer dataObjectID="S2_Level-1C_Product_Metadata"/>
+        </metadataObject>
+        <metadataObject ID="INSPIRE_Metadata_Information" category="DMD" classification="DESCRIPTION">
+            <dataObjectPointer dataObjectID="INSPIRE_Metadata"/>
+        </metadataObject>
+        <metadataObject ID="S2_Level-1C_Datastrip1_Metadata_Information" category="DMD" classification="DESCRIPTION">
+            <dataObjectPointer dataObjectID="S2_Level-1C_Datastrip1_Metadata"/>
+        </metadataObject>
+        <metadataObject ID="S2_Level-1C_Tile1_Metadata_Information" category="DMD" classification="DESCRIPTION">
+            <dataObjectPointer dataObjectID="S2_Level-1C_Tile1_Metadata"/>
+        </metadataObject>
+    </metadataSection>
+    <dataObjectSection>
+        <dataObject ID="S2_Level-1C_Product_Metadata">
+            <byteStream mimeType="text/xml" size="45353">
+                <fileLocation href="./MTD_MSIL1C.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">91CB5B925086749536F310AC7F5E0F2F892CE36FBAA85D6DF2E696EAA64B8400</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="INSPIRE_Metadata">
+            <byteStream mimeType="text/xml" size="18653">
+                <fileLocation href="./INSPIRE.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">1463146EEBA317525C9D5B05CE510C7424D5F3E25CDD8E4CA817E2F637F4B656</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="HTML_Presentation">
+            <byteStream mimeType="octet" size="5793">
+                <fileLocation href="./HTML/UserProduct_index.html" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">037BB08E909E30C92FCF078F2E74FAAF001E0C3447464FFCA2078507304FE52C</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="HTML_Presentation_Stylesheet">
+            <byteStream mimeType="octet" size="10034">
+                <fileLocation href="./HTML/UserProduct_index.xsl" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">19EC86D5D77055C742FBE694EE1658B657FD172FE73875D34735B327F6B4B6C4</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="S2_Level-1C_Datastrip1_Metadata"> <byteStream mimeType="application/xml" size="7598342">
+                <fileLocation href="./DATASTRIP/DS_2BPS_20241209T195414_S20241209T162603/MTD_DS.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">3B00AF86D86E5B54BF07253ADC453FB52E8F686151B78E9D414792AB62D580C2</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="Format_OLQC_Report_Datastrip1_InformationData">
+            <byteStream mimeType="application/xml" size="23051">
+                <fileLocation href="./DATASTRIP/DS_2BPS_20241209T195414_S20241209T162603/QI_DATA/FORMAT_CORRECTNESS.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">40B8F9E535271BAC5BC10D240657A4467266907251101BFCBCC23680C06E3350</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="General_OLQC_Report_Datastrip1_InformationData">
+            <byteStream mimeType="application/xml" size="7778">
+                <fileLocation href="./DATASTRIP/DS_2BPS_20241209T195414_S20241209T162603/QI_DATA/GENERAL_QUALITY.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">027A1D72F7FF1C6A7DD68CC165C5311E82C40B1FF0A1355CFD04C70F61A23981</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="Geometric_OLQC_Report_Datastrip1_InformationData">
+            <byteStream mimeType="application/xml" size="8630">
+                <fileLocation href="./DATASTRIP/DS_2BPS_20241209T195414_S20241209T162603/QI_DATA/GEOMETRIC_QUALITY.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">09CC3AF3937ECDA150B45A936B8A1519872E71F30F0244A757E55B3E6B2098C1</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="Radiometric_OLQC_Report_Datastrip1_InformationData">
+            <byteStream mimeType="application/xml" size="7133">
+                <fileLocation href="./DATASTRIP/DS_2BPS_20241209T195414_S20241209T162603/QI_DATA/RADIOMETRIC_QUALITY.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">9A8625D5DF20B1910A9BE16C77D05B4C45CA6AC5FBC5FB717095DBA3D00A03A9</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="Sensor_OLQC_Report_Datastrip1_InformationData">
+            <byteStream mimeType="application/xml" size="4723">
+                <fileLocation href="./DATASTRIP/DS_2BPS_20241209T195414_S20241209T162603/QI_DATA/SENSOR_QUALITY.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">736DE533044527B89308682218D746965C972BEC60DFED06B001BEBDD25FE657</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="CAMS_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="2970">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/AUX_DATA/AUX_CAMSFO" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">A721E16D3C0886F57EC1FCB7769412FF43C389850B96D2E597A0D3446C19B103</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="ECMWF_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="1620">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/AUX_DATA/AUX_ECMWFT" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">5DC39B632463F835DD0D7CD64786B75F25A5E061C3681FC489203CB1581804A7</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_60m_1_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="3747535">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B01.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">F9D700F56D93636E0702346D96EFE62D876485084B1459DCD1EF737727ABBD33</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_10m_1_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="135133936">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B02.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">2B25B963D2E77B6C1A0BF88C7A8C91B9C6991F437FE1018B1A5B5B2FB7E87860</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_10m_2_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="134257574">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B03.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">873BCC66ED7B95E9EC929B0ECA6801B72FF714ACBEC7121007E91B4A3F34AA71</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_10m_3_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="134701178">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B04.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">1C4E18686E6C0DE89D82AB5F8334B77636224215377E672734D8C7E363FDC3CA</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_20m_1_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="33915716">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B05.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">821568D85ED5CBF83631BFACD70A8F4BC0FC9CD27D3A1C8A5F6C311CF8C16D7F</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_20m_2_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="33722217">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B06.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">A135A1BB4EE78A596627F0538B430C18D6CEEAD7BCF4BF9CAFEE31408B7943A6</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_20m_3_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="33745076">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B07.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">FDB7B76CEA78CC7BDB9D9E7998F628986F4913482F15A3DBB6A1397B9F29EA85</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_10m_4_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="135499538">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B08.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">FD71EA5D823AFF2E79DC81390B52D6B29914FCB5EB343635FFC1F0DB92DE551A</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_60m_2_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="3748197">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B09.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">F410C5B64234C3D4B0B093174AB99860FE0E7171DFDB69DEDA6CA125697926FD</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_60m_3_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="2586775">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B10.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">6417ED6BCF82FC199DD17B3C1AFCA827BDDE3A87D2BFEBF86F81AF6D389F65C8</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_20m_5_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="30780194">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B11.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">E48A90B1F8002F2865196C25703894C5341B1207D9F379DC74C5399DAB14660C</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_20m_6_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="30808362">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B12.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">25D63C0C440C96A974E5C8A290E85F0E2C8B1A23F491399BAFB98B3457676930</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_20m_4_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="33757761">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_B8A.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">D190062FF5613DA70A68CC5EEF3024399F580D2E193408448B175E80CB92B88A</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="IMG_DATA_Band_TCI_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="135138275">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/IMG_DATA/T17UPV_20241209T162609_TCI.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">2EC293A311831382D11F801ACBC0117A7899024DE7EFE41DA7B1722ACC22FA1B</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="S2_Level-1C_Tile1_Metadata"> <byteStream mimeType="application/xml" size="546465">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/MTD_TL.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">A12C9E52A687141D9B668DCE343D1E82F421B8E5A0D5F9478A95E5E6B31985C1</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="Format_OLQC_Report_Tile1_InformationData">
+            <byteStream mimeType="application/xml" size="28445">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/FORMAT_CORRECTNESS.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">683841A67EC38E189FBCFF65176B358BB8D24FC92192078F5F2CCFC813760E98</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="General_OLQC_Report_Tile1_InformationData">
+            <byteStream mimeType="application/xml" size="4276">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/GENERAL_QUALITY.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">A8426B61A8C4174E4F866DD8BC32D90151ECC01A1F03B44D92A9075059C98B3E</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="Geometric_OLQC_Report_Tile1_InformationData">
+            <byteStream mimeType="application/xml" size="5149">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/GEOMETRIC_QUALITY.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">554C649431A4825F8A1AB789BB26EDD6C90718E037A9D680A7EE1B77D328789E</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="ClassiPixelsMask_Band_00m_0_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="97927">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_CLASSI_B00.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">F277BDBF0D2F71DBC755D873F4FB01CF1512A84B48D7280ACCE1594B794410B3</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_60m_1_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="15111">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B01.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">BB96C6C1E04C521021F41FD2328F2BE55EB7800A90180B558865E5FB956CF87B</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_10m_1_1_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="66557">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B02.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">B2DACCCA2E2745E6C580011A9AC0A84CDDAA1927E73717F5630ADDA9A19972C6</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_10m_2_2_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="66495">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B03.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">0D19D5DF93CAE1E00FFD366658E7AD5E19AAB8E2DAE6550257608AECBC4148C6</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_10m_3_3_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="66894">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B04.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">4D37B067C45E6D4447BC666A8DC2E195EABF3049364416ED3BA6E276F0AA5480</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_20m_1_4_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="26678">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B05.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">61663F550905006074F66C5F7ACA5297FF4E98F5BA62E441EAD75DA0ECFD7113</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_20m_2_5_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="27388">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B06.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">3B57C6552C93F441E51E8BBDC7DD0C8B043EB4DEBA34FEB165E5F08FC3A4A60B</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_20m_3_6_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="27092">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B07.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">A5AFBD22B1D9D1F31A3AE9B01C82CAD4266942F1D58AC6D26DB4556E3D42AAA1</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_10m_4_7_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="66582">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B08.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">CF4AEA99127D18E6AA13EE9B6331AA16BB66494526310CF775AD9F11064116F0</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_60m_2_8_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="15229">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B09.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">BE4AC19749ABCF4BCCCB5B89602364542CB3E51D2BD1318ED35521630A9D6655</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_60m_3_9_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="15320">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B10.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">74A9ECD581B96479159EE6BCC6ACC335637C038F508B5BE89F01E0D5D57F941F</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_20m_5_10_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="27070">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B11.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">6466B35D0DB80890B38437D419FA08BBFEC6CEA01A56C00087355936AF7EA153</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_20m_6_11_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="27218">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B12.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">8DE0EFE9848DD322CA040E0574186B691F171245478013BFF8634BF5D4B3B65D</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="DetectorFootprintMask_Band_20m_4_12_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="26645">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_DETFOO_B8A.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">59C0643A4134DA0548D7B8473F564C2406AF7A9E616ADCE7BC9D55A869314123</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_60m_1_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="14764">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B01.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">F6D6D77B0780A66FBB4F8172243B92517DB6E37E6746D07950B940C194808E69</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_10m_1_1_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="56612">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B02.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">1D9CCD23CAD257620691C9895B460D6CBB96F0DF1EC886C450D1BDA61C281D20</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_10m_2_2_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="56612">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B03.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">1D9CCD23CAD257620691C9895B460D6CBB96F0DF1EC886C450D1BDA61C281D20</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_10m_3_3_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="56612">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B04.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">1D9CCD23CAD257620691C9895B460D6CBB96F0DF1EC886C450D1BDA61C281D20</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_20m_1_4_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="13997">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B05.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">3FEFAC1F12D8118701BF3B650FFEDC898B1BD6A829F32F1E68C636F8CFBB0D1C</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_20m_2_5_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="13997">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B06.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">3FEFAC1F12D8118701BF3B650FFEDC898B1BD6A829F32F1E68C636F8CFBB0D1C</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_20m_3_6_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="13997">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B07.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">3FEFAC1F12D8118701BF3B650FFEDC898B1BD6A829F32F1E68C636F8CFBB0D1C</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_10m_4_7_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="56612">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B08.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">1D9CCD23CAD257620691C9895B460D6CBB96F0DF1EC886C450D1BDA61C281D20</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_60m_2_8_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="14764">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B09.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">F6D6D77B0780A66FBB4F8172243B92517DB6E37E6746D07950B940C194808E69</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_60m_3_9_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="20580">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B10.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">1B758CAF2FC75F5247FEA39C038F458014177047207ED8B36A55ADA1F7230F06</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_20m_5_10_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="27393">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B11.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">45DC230798AD682DB4ECE344D26AC9B5F4AAF0F286307C3D1A352209E0AF278D</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_20m_6_11_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="27349">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B12.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">85A15AB0FDF348150D5BE7BF11760627B0C0C81E03758E27733EFC4399529BBF</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="QualitPixelsMask_Band_20m_4_12_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="13997">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/MSK_QUALIT_B8A.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">3FEFAC1F12D8118701BF3B650FFEDC898B1BD6A829F32F1E68C636F8CFBB0D1C</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="Sensor_OLQC_Report_Tile1_InformationData">
+            <byteStream mimeType="application/xml" size="5239">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/SENSOR_QUALITY.xml" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">085CCF405B7A5735AC1CAE54325265FBC0CF487DA3CAAB982F926C0169D997F4</checksum>
+            </byteStream>
+        </dataObject>
+        <dataObject ID="Preview_0_Tile1_Data">
+            <byteStream mimeType="application/octet-stream" size="166060">
+                <fileLocation href="./GRANULE/L1C_T17UPV_A040535_20241209T162603/QI_DATA/T17UPV_20241209T162609_PVI.jp2" locatorType="URL"/>
+                <checksum checksumName="SHA3-256">9E7FCE6D5B5942C62B05D9644EB35297CA20E794E3D1C3DF6CEF1A4543732B0A</checksum>
+            </byteStream>
+        </dataObject>
+    </dataObjectSection>
+</xfdu:XFDU>

--- a/tests/download/mock/sentinel_3/xfdumanifest.xml
+++ b/tests/download/mock/sentinel_3/xfdumanifest.xml
@@ -1,0 +1,2694 @@
+<?xml version ="1.0" encoding="UTF-8"?>
+   <xfdu:XFDU xmlns:xfdu="urn:ccsds:schema:xfdu:1" xmlns:sentinel-safe="http://www.esa.int/safe/sentinel/1.1" xmlns:gml="http://www.opengis.net/gml" xmlns:sentinel3="http://www.esa.int/safe/sentinel/sentinel-3/1.0" xmlns:olci="http://www.esa.int/safe/sentinel/sentinel-3/olci/1.0" version="esa/safe/sentinel/sentinel-3/olci/level-2/1.0">
+      <informationPackageMap>
+         <xfdu:contentUnit ID="packageUnit" unitType="Information Package" textInfo="SENTINEL-3 OLCI Level 2 Water Product" dmdID="acquisitionPeriod platform measurementOrbitReference measurementQualityInformation processing measurementFrameSet generalProductInformation olciProductInformation" pdiID="processing">
+            <xfdu:contentUnit  ID="Oa01_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa01" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa01_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa02_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa02" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa02_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa03_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa03" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa03_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa04_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa04" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa04_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa05_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa05" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa05_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa06_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa06" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa06_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa07_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa07" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa07_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa08_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa08" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa08_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa09_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa09" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa09_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa10_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa10" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa10_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa11_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa11" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa11_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa12_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa12" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa12_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa16_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa16" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa16_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa17_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa17" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa17_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa18_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa18" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa18_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="Oa21_reflectanceUnit" unitType="Measurement Data Unit" textInfo="Reflectance for OLCI acquisition band Oa21" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation wqsfAnnotation">
+               <dataObjectPointer dataObjectID="Oa21_reflectanceData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="chlNnUnit" unitType="Measurement Data Unit" textInfo="Neural Net Chlorophyll concentration" dmdID="wqsfAnnotation timeCoordinatesAnnotation geoCoordinatesAnnotation tieGeoCoordinatesAnnotation tieGeometriesAnnotation tieMeteoAnnotation instrumentDataAnnotation">
+               <dataObjectPointer dataObjectID="chlNnData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="chlOc4meUnit" unitType="Measurement Data Unit" textInfo="OC4Me algorithm Chlorophyll concentration" dmdID="wqsfAnnotation timeCoordinatesAnnotation geoCoordinatesAnnotation tieGeoCoordinatesAnnotation tieGeometriesAnnotation tieMeteoAnnotation instrumentDataAnnotation">
+               <dataObjectPointer dataObjectID="chlOc4meData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="geoCoordinatesUnit" unitType="Annotation Data Unit" textInfo="Geo Coordinates Annotations" dmdID="timeCoordinatesAnnotation">
+               <dataObjectPointer dataObjectID="geoCoordinatesData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="instrumentDataUnit" unitType="Annotation Data Unit" textInfo="Instrument Annotation" dmdID="geoCoordinatesAnnotation timeCoordinatesAnnotation">
+               <dataObjectPointer dataObjectID="instrumentDataData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="iopLsdUnit" unitType="Measurement Data Unit" textInfo="Inherent Optical Properties of water" dmdID="wqsfAnnotation timeCoordinatesAnnotation geoCoordinatesAnnotation tieGeoCoordinatesAnnotation tieGeometriesAnnotation tieMeteoAnnotation instrumentDataAnnotation">
+               <dataObjectPointer dataObjectID="iopLsdData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="iopNnUnit" unitType="Measurement Data Unit" textInfo="Inherent Optical Properties of water" dmdID="wqsfAnnotation timeCoordinatesAnnotation geoCoordinatesAnnotation tieGeoCoordinatesAnnotation tieGeometriesAnnotation tieMeteoAnnotation instrumentDataAnnotation">
+               <dataObjectPointer dataObjectID="iopNnData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="iwvUnit" unitType="Measurement Data Unit" textInfo="Integrated water vapour column" dmdID="wqsfAnnotation timeCoordinatesAnnotation geoCoordinatesAnnotation tieGeoCoordinatesAnnotation tieGeometriesAnnotation tieMeteoAnnotation instrumentDataAnnotation">
+               <dataObjectPointer dataObjectID="iwvData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="parUnit" unitType="Measurement Data Unit" textInfo="Photosynthetically Active Radiation" dmdID="wqsfAnnotation timeCoordinatesAnnotation geoCoordinatesAnnotation tieGeoCoordinatesAnnotation tieGeometriesAnnotation tieMeteoAnnotation instrumentDataAnnotation">
+               <dataObjectPointer dataObjectID="parData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="tieGeoCoordinatesUnit" unitType="Annotation Data Unit" textInfo="Tie-Point Geo Coordinate Annotations" dmdID="timeCoordinatesAnnotation">
+               <dataObjectPointer dataObjectID="tieGeoCoordinatesData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="tieGeometriesUnit" unitType="Annotation Data Unit" textInfo="Tie-Point Geometries Annotations" dmdID="tieGeoCoordinatesAnnotation timeCoordinatesAnnotation">
+               <dataObjectPointer dataObjectID="tieGeometriesData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="tieMeteoUnit" unitType="Annotation Data Unit" textInfo="Tie-Point Meteo Annotations" dmdID="timeCoordinatesAnnotation tieGeoCoordinatesAnnotation">
+               <dataObjectPointer dataObjectID="tieMeteoData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="timeCoordinatesUnit" unitType="Annotation Data Unit" textInfo="Time Coordinates Annotations">
+               <dataObjectPointer dataObjectID="timeCoordinatesData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="trspUnit" unitType="Measurement Data Unit" textInfo="Transparency properties of water" dmdID="wqsfAnnotation timeCoordinatesAnnotation geoCoordinatesAnnotation tieGeoCoordinatesAnnotation tieGeometriesAnnotation tieMeteoAnnotation instrumentDataAnnotation">
+               <dataObjectPointer dataObjectID="trspData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="tsmNnUnit" unitType="Measurement Data Unit" textInfo="Total suspended matter concentration" dmdID="wqsfAnnotation timeCoordinatesAnnotation geoCoordinatesAnnotation tieGeoCoordinatesAnnotation tieGeometriesAnnotation tieMeteoAnnotation instrumentDataAnnotation">
+               <dataObjectPointer dataObjectID="tsmNnData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="wAerUnit" unitType="Measurement Data Unit" textInfo="Aerosol Over Water" dmdID="wqsfAnnotation timeCoordinatesAnnotation geoCoordinatesAnnotation tieGeoCoordinatesAnnotation tieGeometriesAnnotation tieMeteoAnnotation instrumentDataAnnotation">
+               <dataObjectPointer dataObjectID="wAerData"/>
+            </xfdu:contentUnit>
+            <xfdu:contentUnit  ID="wqsfUnit" unitType="Annotation Data Unit" textInfo="Water Quality and Science Flags" dmdID="timeCoordinatesAnnotation geoCoordinatesAnnotation tieGeoCoordinatesAnnotation tieGeometriesAnnotation tieMeteoAnnotation instrumentDataAnnotation">
+               <dataObjectPointer dataObjectID="wqsfData"/>
+            </xfdu:contentUnit>
+         </xfdu:contentUnit>
+      </informationPackageMap>
+      <metadataSection>
+         <metadataObject ID="acquisitionPeriod" classification="DESCRIPTION" category="DMD">
+            <metadataWrap mimeType="text/xml" vocabularyName="Sentinel-SAFE" textInfo="Acquisition Period">
+               <xmlData>
+                  <sentinel-safe:acquisitionPeriod>
+                     <sentinel-safe:startTime>2024-12-17T09:53:04.547252Z</sentinel-safe:startTime>
+                     <sentinel-safe:stopTime>2024-12-17T09:56:04.547252Z</sentinel-safe:stopTime>
+                  </sentinel-safe:acquisitionPeriod>
+               </xmlData>
+            </metadataWrap>
+         </metadataObject>
+         <metadataObject ID="platform" classification="DESCRIPTION" category="DMD">
+            <metadataWrap mimeType="text/xml" vocabularyName="Sentinel-SAFE" textInfo="Platform Description">
+               <xmlData>
+                  <sentinel-safe:platform>
+                     <sentinel-safe:nssdcIdentifier>2018-039A</sentinel-safe:nssdcIdentifier>
+                     <sentinel-safe:familyName>Sentinel-3</sentinel-safe:familyName>
+                     <sentinel-safe:number>B</sentinel-safe:number>
+                     <sentinel-safe:instrument>
+                        <sentinel-safe:familyName abbreviation="OLCI">Ocean Land Colour Instrument</sentinel-safe:familyName>
+                        <sentinel-safe:mode identifier="EO">Earth Observation</sentinel-safe:mode>
+                     </sentinel-safe:instrument>
+                  </sentinel-safe:platform>
+               </xmlData>
+            </metadataWrap>
+         </metadataObject>
+         <metadataObject ID="measurementFrameSet" classification="DESCRIPTION" category="DMD">
+            <metadataWrap mimeType="text/xml" vocabularyName="Sentinel-SAFE" textInfo="Frame Set">
+               <xmlData>
+                  <sentinel-safe:frameSet>
+                     <sentinel-safe:footPrint srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                        <gml:posList>41.9628 -2.91463 41.8855 -2.06724 41.8044 -1.25962 41.7151 -0.431305 41.6236 0.385984 41.5227 1.20932 41.4179 2.01602 41.3057 2.82933 41.1887 3.63549 41.0651 4.44499 40.9371 5.2492 40.8031 6.04903 40.6638 6.84423 40.5194 7.64004 40.3687 8.43185 40.2131 9.21817 40.0519 9.99997 39.8854 10.7801 39.7136 11.5562 39.5378 12.3285 42.1353 13.3764 44.7284 14.5088 47.3102 15.7387 49.8787 17.0852 50.0827 16.1752 50.281 15.256 50.4712 14.3324 50.6546 13.4002 50.8298 12.4625 50.9977 11.5164 51.1572 10.5629 51.3096 9.60446 51.4543 8.63883 51.5902 7.66771 51.719 6.69084 51.84 5.70593 51.9528 4.71557 52.0567 3.72378 52.1524 2.7262 52.2366 1.72982 52.3154 0.725536 52.386 -0.28795 52.446 -1.29599 49.8263 -1.69214 47.2049 -2.09383 44.582 -2.50158 41.9628 -2.91463</gml:posList>
+                     </sentinel-safe:footPrint>
+                  </sentinel-safe:frameSet>
+               </xmlData>
+            </metadataWrap>
+         </metadataObject>
+         <metadataObject ID="generalProductInformation" classification="DESCRIPTION" category="DMD">
+            <metadataWrap mimeType="text/xml" vocabularyName="Sentinel-SAFE" textInfo="General Product Information">
+               <xmlData>
+                  <sentinel3:generalProductInformation>
+                     <sentinel3:productName>S3B_OL_2_WFR____20241217T095305_20241217T095605_20241218T170707_0179_101_079_2160_MAR_O_NT_003.SEN3</sentinel3:productName>
+                     <sentinel3:productType>OL_2_WFR___</sentinel3:productType>
+                     <sentinel3:timeliness>NT</sentinel3:timeliness>
+                     <sentinel3:baselineCollection>003</sentinel3:baselineCollection>
+                     <sentinel3:processingBaseline>OL__L2M.003.05.01</sentinel3:processingBaseline>
+                     <sentinel3:creationTime>20241218T170707</sentinel3:creationTime>
+                     <sentinel3:productSize>229073837</sentinel3:productSize>
+                     <sentinel3:dumpInformation>
+                        <sentinel3:granuleNumber>1</sentinel3:granuleNumber>
+                        <sentinel3:granulePosition>FIRST</sentinel3:granulePosition>
+                        <sentinel3:dumpStart>2024-12-17T09:51:35.043217Z</sentinel3:dumpStart>
+                        <sentinel3:receivingGroundStation>CGS</sentinel3:receivingGroundStation>
+                        <sentinel3:receivingStartTime>2024-12-17T11:22:26.704865Z</sentinel3:receivingStartTime>
+                        <sentinel3:receivingStopTime>2024-12-17T11:22:47.692367Z</sentinel3:receivingStopTime>
+                     </sentinel3:dumpInformation>
+                     <sentinel3:dispositionMode>Operational</sentinel3:dispositionMode>
+                     <sentinel3:productUnit>
+                        <sentinel3:type>FRAME</sentinel3:type>
+                        <sentinel3:duration>179</sentinel3:duration>
+                        <sentinel3:alongtrackCoordinate>2160</sentinel3:alongtrackCoordinate>
+                     </sentinel3:productUnit>
+                  </sentinel3:generalProductInformation>
+               </xmlData>
+            </metadataWrap>
+         </metadataObject>
+         <metadataObject ID="olciProductInformation" classification="DESCRIPTION" category="DMD">
+            <metadataWrap mimeType="text/xml" vocabularyName="Sentinel-SAFE" textInfo="Olci Product Information">
+               <xmlData>
+                  <olci:olciProductInformation>
+                     <olci:classificationSummary>
+                        <sentinel3:salineWaterPixels percentage="12.000000"/>
+                        <sentinel3:coastalPixels percentage="0.003900"/>
+                        <sentinel3:freshInlandWaterPixels percentage="1.000000"/>
+                        <sentinel3:tidalRegionPixels percentage="0.000000"/>
+                        <sentinel3:landPixels percentage="77.000000"/>
+                        <sentinel3:cloudyPixels percentage="63.000000"/>
+                     </olci:classificationSummary>
+                     <olci:atmosphericCorrectionType>PARALLEL</olci:atmosphericCorrectionType>
+                     <olci:measurementAccuracy>2.000000</olci:measurementAccuracy>
+                     <olci:accuracyReference>0</olci:accuracyReference>
+                     <olci:imageSize>
+                        <sentinel3:rows>4091</sentinel3:rows>
+                        <sentinel3:columns>4865</sentinel3:columns>
+                     </olci:imageSize>
+                     <olci:pixelQualitySummary>
+                        <olci:invalidPixels value="741704" percentage="4.000000"/>
+                        <olci:cosmeticPixels value="383607" percentage="2.000000"/>
+                        <olci:duplicatedPixels value="4672521" percentage="1.595621"/>
+                        <olci:saturatedPixels value="264602" percentage="1.000000"/>
+                        <olci:dubiousSamples value="4091" percentage="0.000000"/>
+                     </olci:pixelQualitySummary>
+                     <olci:ecmwfType timeRelevance="0">ANALYSIS</olci:ecmwfType>
+                     <olci:earthSunDistance>147208476701</olci:earthSunDistance>
+                     <olci:oclStatus>true</olci:oclStatus>
+                     <olci:samplingParameters>
+                        <olci:alTimeSampling>44002</olci:alTimeSampling>
+                        <olci:alSpatialSampling>294</olci:alSpatialSampling>
+                        <olci:acSpatialSampling>270</olci:acSpatialSampling>
+                        <olci:rowsPerTiePoint>1</olci:rowsPerTiePoint>
+                        <olci:columnsPerTiePoint>64</olci:columnsPerTiePoint>
+                     </olci:samplingParameters>
+                     <olci:bandDescriptions bands="16">
+                        <sentinel3:band name="Oa01">
+                           <sentinel3:centralWavelength>400</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>15</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa02">
+                           <sentinel3:centralWavelength>412.5</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>10</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa03">
+                           <sentinel3:centralWavelength>442.5</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>10</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa04">
+                           <sentinel3:centralWavelength>490</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>10</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa05">
+                           <sentinel3:centralWavelength>510</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>10</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa06">
+                           <sentinel3:centralWavelength>560</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>10</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa07">
+                           <sentinel3:centralWavelength>620</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>10</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa08">
+                           <sentinel3:centralWavelength>665</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>10</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa09">
+                           <sentinel3:centralWavelength>673.75</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>7.5</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa10">
+                           <sentinel3:centralWavelength>681.25</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>7.5</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa11">
+                           <sentinel3:centralWavelength>708.75</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>10</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa12">
+                           <sentinel3:centralWavelength>753.75</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>7.5</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa16">
+                           <sentinel3:centralWavelength>778.75</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>15</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa17">
+                           <sentinel3:centralWavelength>865</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>20</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa18">
+                           <sentinel3:centralWavelength>885</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>10</sentinel3:bandwidth>
+                        </sentinel3:band>
+                        <sentinel3:band name="Oa21">
+                           <sentinel3:centralWavelength>1020</sentinel3:centralWavelength>
+                           <sentinel3:bandwidth>40</sentinel3:bandwidth>
+                        </sentinel3:band>
+                     </olci:bandDescriptions>
+                  </olci:olciProductInformation>
+               </xmlData>
+            </metadataWrap>
+         </metadataObject>
+         <metadataObject ID="measurementOrbitReference" classification="DESCRIPTION" category="DMD">
+            <metadataWrap mimeType="text/xml" vocabularyName="Sentinel-SAFE" textInfo="Orbit Reference">
+               <xmlData>
+                  <sentinel-safe:orbitReference>
+                     <sentinel-safe:orbitNumber type="start" groundTrackDirection="descending">34616</sentinel-safe:orbitNumber>
+                     <sentinel-safe:relativeOrbitNumber type="start" groundTrackDirection="descending">79</sentinel-safe:relativeOrbitNumber>
+                     <sentinel-safe:passNumber type="start" groundTrackDirection="descending">69232</sentinel-safe:passNumber>
+                     <sentinel-safe:relativePassNumber type="start" groundTrackDirection="descending">158</sentinel-safe:relativePassNumber>
+                     <sentinel-safe:cycleNumber>101</sentinel-safe:cycleNumber>
+                     <sentinel-safe:phaseIdentifier>4</sentinel-safe:phaseIdentifier>
+                     <sentinel-safe:elementSet>
+                        <sentinel-safe:ephemeris>
+                           <sentinel-safe:epoch type="TAI">2024-12-17T09:17:41.547252</sentinel-safe:epoch>
+                           <sentinel-safe:epoch type="UTC">2024-12-17T09:17:04.547252Z</sentinel-safe:epoch>
+                           <sentinel-safe:epoch type="UT1">2024-12-17T09:17:04.596577</sentinel-safe:epoch>
+                           <sentinel-safe:position>
+                              <sentinel-safe:x>-7053536.5159999998</sentinel-safe:x>
+                              <sentinel-safe:y>-1360183.953</sentinel-safe:y>
+                              <sentinel-safe:z>0.002</sentinel-safe:z>
+                           </sentinel-safe:position>
+                           <sentinel-safe:velocity>
+                              <sentinel-safe:x>-301.98742299999998</sentinel-safe:x>
+                              <sentinel-safe:y>1612.5008439999999</sentinel-safe:y>
+                              <sentinel-safe:z>7366.681732</sentinel-safe:z>
+                           </sentinel-safe:velocity>
+                        </sentinel-safe:ephemeris>
+                        <sentinel-safe:ephemeris>
+                           <sentinel-safe:epoch type="TAI">2024-12-17T10:58:40.688824</sentinel-safe:epoch>
+                           <sentinel-safe:epoch type="UTC">2024-12-17T10:58:03.688824Z</sentinel-safe:epoch>
+                           <sentinel-safe:epoch type="UT1">2024-12-17T10:58:03.738150</sentinel-safe:epoch>
+                           <sentinel-safe:position>
+                              <sentinel-safe:x>-6959929.3679999998</sentinel-safe:x>
+                              <sentinel-safe:y>1778236.7890000001</sentinel-safe:y>
+                              <sentinel-safe:z>0.001</sentinel-safe:z>
+                           </sentinel-safe:position>
+                           <sentinel-safe:velocity>
+                              <sentinel-safe:x>414.607641</sentinel-safe:x>
+                              <sentinel-safe:y>1587.337254</sentinel-safe:y>
+                              <sentinel-safe:z>7366.6733510000004</sentinel-safe:z>
+                           </sentinel-safe:velocity>
+                        </sentinel-safe:ephemeris>
+                     </sentinel-safe:elementSet>
+                  </sentinel-safe:orbitReference>
+               </xmlData>
+            </metadataWrap>
+         </metadataObject>
+         <metadataObject ID="measurementQualityInformation" classification="DESCRIPTION" category="DMD">
+            <metadataWrap mimeType="text/xml" vocabularyName="Sentinel-SAFE" textInfo="Quality Information">
+               <xmlData>
+                  <sentinel-safe:qualityInformation>
+                     <sentinel-safe:extension>
+                        <sentinel3:productQuality>
+                           <sentinel3:onlineQualityCheck>PASSED</sentinel3:onlineQualityCheck>
+                           <sentinel3:degradationFlags>NON_NOMINAL_INPUT</sentinel3:degradationFlags>
+                        </sentinel3:productQuality>
+                     </sentinel-safe:extension>
+                  </sentinel-safe:qualityInformation>
+               </xmlData>
+            </metadataWrap>
+         </metadataObject>
+         <metadataObject ID="processing" classification="PROVENANCE" category="PDI">
+            <metadataWrap mimeType="text/xml" vocabularyName="Sentinel-SAFE" textInfo="Processing">
+               <xmlData>
+                  <sentinel-safe:processing name="DataProcessing" outputLevel="2" start="2024-12-18T17:09:57.000000" stop="2024-12-18T17:09:59.807384">
+                     <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                        <sentinel-safe:hardware name="OPE"/>
+                        <sentinel-safe:software name="PUG" version="03.51"/>
+                     </sentinel-safe:facility>
+                     <sentinel-safe:resource name="S3IPF PDS 004.3 - Product Data Format Specification - OLCI Level 2 Marine" role="Product Data Format Specification" version="2.4"/>
+                     <sentinel-safe:resource name="Metadata Specification, Excel document S3IPF.PDS.008" role="Metadata Specification" version="3.10"/>
+                     <sentinel-safe:resource name="S3B_OL_2_WFR____20241217T095137_20241217T103545_20241218T125759_2648_101_079______MAR_O_NT_003.SEN3" role="L2 Product">
+                        <sentinel-safe:processing name="DataProcessing" outputLevel="2" start="2024-12-18T12:57:34.127026" stop="2024-12-18T16:48:04.723860">
+                           <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                              <sentinel-safe:hardware name="OPE"/>
+                              <sentinel-safe:software name="IPF-OL-2" version="07.06"/>
+                           </sentinel-safe:facility>
+                           <sentinel-safe:resource name="S3B_OL_1_EFR____20241217T095137_20241217T103545_20241218T111735_2648_101_079______MAR_O_NT_004.SEN3" role="input_product">
+                              <sentinel-safe:processing name="DataProcessing" outputLevel="1" start="2024-12-18T11:17:15.222733" stop="2024-12-18T12:53:11.436799">
+                                 <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                    <sentinel-safe:hardware name="OPE"/>
+                                    <sentinel-safe:software name="IPF-OL-1-EO" version="06.19"/>
+                                 </sentinel-safe:facility>
+                                 <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product;Orbit File">
+                                    <sentinel-safe:processing name="DataProcessing" outputLevel="0" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                       <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                          <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                             <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="2.0"/>
+                                             </sentinel-safe:facility>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                          <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                             <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="2.0"/>
+                                             </sentinel-safe:facility>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                          <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                             <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="2.0"/>
+                                             </sentinel-safe:facility>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product;Orbit File">
+                                    <sentinel-safe:processing name="DataProcessing" outputLevel="0" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                       <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                          <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                             <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="2.0"/>
+                                             </sentinel-safe:facility>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                          <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                             <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="2.0"/>
+                                             </sentinel-safe:facility>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                          <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                             <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="2.0"/>
+                                             </sentinel-safe:facility>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T095137_20241217T103545_20241217T154650_2648_101_079______MAR_O_NR_002.SEN3" role="L0 Product">
+                                    <sentinel-safe:processing name="DataProcessing" outputLevel="0" start="2024-12-17T15:46:39.798881" stop="2024-12-17T15:47:17.271578">
+                                       <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="PUG" version="03.51"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3IPF PDS 001 - i1r1 - Product Data Format Specification - Level 0" role="Applicable Document" version="1.6">
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T095137_20241217T095335_20241217T113551_0118_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:35:49.600723" stop="2024-12-17T11:35:59.137039">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T095153_20241217T095353_20241217T113330_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T095335_20241217T095535_20241217T113551_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:35:49.905855" stop="2024-12-17T11:35:59.656694">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T095353_20241217T095553_20241217T113306_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T095535_20241217T095735_20241217T113552_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:35:50.037666" stop="2024-12-17T11:36:00.733442">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T095553_20241217T095753_20241217T113307_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T095735_20241217T095935_20241217T113631_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:36:29.584683" stop="2024-12-17T11:36:40.389712">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T095753_20241217T095953_20241217T113307_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T095935_20241217T100135_20241217T113631_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:36:29.676917" stop="2024-12-17T11:36:39.428537">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T095953_20241217T100153_20241217T113308_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T100135_20241217T100335_20241217T113631_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:36:29.437297" stop="2024-12-17T11:36:38.777541">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T100153_20241217T100353_20241217T113309_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T100335_20241217T100535_20241217T113710_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:37:08.453569" stop="2024-12-17T11:37:17.673898">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T100353_20241217T100553_20241217T113309_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T100535_20241217T100735_20241217T113710_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:37:08.313876" stop="2024-12-17T11:37:18.998213">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T100553_20241217T100753_20241217T113310_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T100735_20241217T100935_20241217T113731_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:37:29.912594" stop="2024-12-17T11:37:38.954289">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T100753_20241217T100953_20241217T113311_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T100935_20241217T101135_20241217T113732_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:37:30.100967" stop="2024-12-17T11:37:39.830911">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T100953_20241217T101153_20241217T113311_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T101135_20241217T101335_20241217T113732_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:37:30.077760" stop="2024-12-17T11:37:40.847416">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T101153_20241217T101353_20241217T113312_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T101335_20241217T101535_20241217T113751_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:37:49.543839" stop="2024-12-17T11:37:58.885859">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T101353_20241217T101553_20241217T113312_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T101535_20241217T101735_20241217T113813_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:38:10.972469" stop="2024-12-17T11:38:21.535005">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T101553_20241217T101753_20241217T113312_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T101735_20241217T101935_20241217T113812_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:38:10.445611" stop="2024-12-17T11:38:21.259602">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T101753_20241217T101953_20241217T113313_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T101935_20241217T102135_20241217T113812_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:38:10.192037" stop="2024-12-17T11:38:19.436585">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T101953_20241217T102153_20241217T113313_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T102135_20241217T102335_20241217T113813_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:38:11.052469" stop="2024-12-17T11:38:20.719652">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T102153_20241217T102353_20241217T113314_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T102335_20241217T102535_20241217T113833_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:38:31.387579" stop="2024-12-17T11:38:40.789984">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T102353_20241217T102553_20241217T113315_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T102535_20241217T102735_20241217T113911_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:39:09.687746" stop="2024-12-17T11:39:20.104285">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T102553_20241217T102753_20241217T113316_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T102735_20241217T102935_20241217T113852_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:38:50.927698" stop="2024-12-17T11:39:00.250586">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T102753_20241217T102953_20241217T113316_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T102935_20241217T103135_20241217T113853_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:38:50.923502" stop="2024-12-17T11:39:01.387682">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T102953_20241217T103153_20241217T113318_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T103135_20241217T103335_20241217T113911_0119_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:39:09.197493" stop="2024-12-17T11:39:18.505630">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T103153_20241217T103353_20241217T113319_0120______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_EFR____20241217T103335_20241217T103545_20241217T113931_0130_101_079______MAR_O_NR_002.SEN3" role="L0 Product" version="1.6">
+                                          <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:39:29.383691" stop="2024-12-17T11:39:38.773735">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_EFR__G_20241217T103353_20241217T103603_20241217T113330_0130______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112218_20241217T113423_6016_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.231483" stop="2024-12-17T11:34:34.259578">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112236_20241217T112439_6016______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241217T094202_20241217T112229_20241217T113422_6026_101_079______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" start="2024-12-17T11:34:22.075398" stop="2024-12-17T11:34:31.294010">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241217T094220_20241217T112247_20241217T113302_6027______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_AX___FRO_AX_20241214T000000_20241224T000000_20241217T064631___________________EUM_O_AL_001.SEN3" role="Orbit File" version="1.6">
+                                          <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                             <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="2.0"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_OPER_MPL_ORBRES_20241214T000000_20241224T000000_0001.EOF" role="Raw Data" version="0001">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File" version="1.6">
+                                          <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                             <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="2.0"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_OPER_MPL_ORBSCT_20180425T191855_99999999T999999_0011.TGZ" role="Raw Data" version="0011">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3B_OL_1_RAC____20241215T195349_20241215T195435_20241215T204550_0045_101_056______MAR_O_NR_004.SEN3" role="L1 Product;OLCI calibration product containing dark offset and gain coefficients from radiometric calibration">
+                                    <sentinel-safe:processing name="DataProcessing" outputLevel="1" start="2024-12-15T20:45:42.213017" stop="2024-12-15T20:45:50.135255">
+                                       <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="IPF-OL-1-RAC" version="06.17"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3B_TM_0_NAT____20241215T185328_20241215T203346_20241215T204444_6017_101_056______MAR_O_AL_002.SEN3" role="L0 Product">
+                                          <sentinel-safe:processing name="DataProcessing" outputLevel="0" start="2024-12-15T20:44:43.300379" stop="2024-12-15T20:44:55.582206">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241215T185346_20241215T203404_20241215T203536_6018______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_TM_0_NAT____20241215T185328_20241215T203351_20241215T204443_6022_101_056______MAR_O_AL_002.SEN3" role="L0 Product">
+                                          <sentinel-safe:processing name="DataProcessing" outputLevel="0" start="2024-12-15T20:44:42.825140" stop="2024-12-15T20:44:52.036633">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241215T185346_20241215T203409_20241215T204305_6023______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_0_CR0____20241215T195349_20241215T195435_20241215T204528_0045_101_056______MAR_O_NR_002.SEN3" role="L0 Product">
+                                          <sentinel-safe:processing name="DataProcessing" outputLevel="0" start="2024-12-15T20:45:26.730738" stop="2024-12-15T20:45:35.648841">
+                                             <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                                   <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="ADC" version="2.0"/>
+                                                   </sentinel-safe:facility>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_OL_0_CR___G_20241215T190909_20241215T195453_20241215T204309_2744______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241215T185328_20241215T203346_20241215T204444_6017_101_056______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241215T185328_20241215T203346_20241215T204444_6017_101_056______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" outputLevel="0" start="2024-12-15T20:44:43.300379" stop="2024-12-15T20:44:55.582206">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241215T185346_20241215T203404_20241215T203536_6018______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241215T185328_20241215T203351_20241215T204443_6022_101_056______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" outputLevel="0" start="2024-12-15T20:44:42.825140" stop="2024-12-15T20:44:52.036633">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241215T185346_20241215T203409_20241215T204305_6023______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241215T185328_20241215T203346_20241215T204444_6017_101_056______MAR_O_AL_002.SEN3" role="Orbit File">
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241215T185328_20241215T203346_20241215T204444_6017_101_056______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" outputLevel="0" start="2024-12-15T20:44:43.300379" stop="2024-12-15T20:44:55.582206">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241215T185346_20241215T203404_20241215T203536_6018______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3B_TM_0_NAT____20241215T185328_20241215T203351_20241215T204443_6022_101_056______MAR_O_AL_002.SEN3" role="L0 Product">
+                                                <sentinel-safe:processing name="DataProcessing" outputLevel="0" start="2024-12-15T20:44:42.825140" stop="2024-12-15T20:44:52.036633">
+                                                   <sentinel-safe:facility name="Marine Processing and Archiving Centre [MAR]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                      <sentinel-safe:hardware name="OPE"/>
+                                                      <sentinel-safe:software name="IPF-0" version="06.17"/>
+                                                   </sentinel-safe:facility>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="Time Correlation File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted)">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3B_TM_0_NAT__G_20241215T185346_20241215T203409_20241215T204305_6023______________SVL_O_NR_OPE.ISIP" role="L0PP Granule">
+                                                   </sentinel-safe:resource>
+                                                   <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                                   </sentinel-safe:resource>
+                                                </sentinel-safe:processing>
+                                             </sentinel-safe:resource>
+                                             <sentinel-safe:resource name="S3IPF PDS 001 - i1r8 - Product Data Format Specification - Level 0" role="Product Data Format Specification - Level 0">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_1_RAC_AX_20180425T000000_20991231T235959_20210309T120000___________________MPC_O_AL_003.SEN3" role="OLCI L1 Processing Control Parameter file in RC mode">
+                                          <sentinel-safe:processing name="AdfProcessing">
+                                             <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="1.0"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3IPF PDS 007.1 - Auxiliary Data Format Specification - OLCI Level 1" role="Auxiliary Data Format Specification" version="2.11">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_1_INS_AX_20201030T120000_20991231T235959_20220505T120000___________________MPC_O_AL_008.SEN3" role="OLCI Characterisation and Models Data file">
+                                          <sentinel-safe:processing name="AdfProcessing">
+                                             <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="1.0"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3IPF PDS 007.1 - Auxiliary Data Format Specification - OLCI Level 1" role="Auxiliary Data Format Specification" version="2.13">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_1_CAL_AX_20240402T234000_20991231T235959_20240405T120000___________________MPC_O_AL_021.SEN3" role="OLCI Calibration Data file">
+                                          <sentinel-safe:processing name="AdfProcessing">
+                                             <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="1.0"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3IPF PDS 007.1 - Auxiliary Data Format Specification - OLCI Level 1" role="Auxiliary Data Format Specification" version="2.17">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_OL_1_PRG_AX_20180618T000000_20991231T235959_20240604T101746___________________MPC_O_AL_004.SEN3" role="OLCI Programmation Data file">
+                                          <sentinel-safe:processing name="AdfProcessing">
+                                             <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="1.0"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3IPF PDS 007.1 - Auxiliary Data Format Specification - OLCI Level 1" role="Auxiliary Data Format Specification" version="2.11">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_AX___FRO_AX_20241212T000000_20241222T000000_20241215T064438___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted);Time Correlation File">
+                                          <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                             <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="2.0"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_OPER_MPL_ORBRES_20241212T000000_20241222T000000_0001.EOF" role="Raw Data" version="0001">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                          <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                             <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                                <sentinel-safe:hardware name="OPE"/>
+                                                <sentinel-safe:software name="ADC" version="2.0"/>
+                                             </sentinel-safe:facility>
+                                             <sentinel-safe:resource name="S3B_OPER_MPL_ORBSCT_20180425T191855_99999999T999999_0011.TGZ" role="Raw Data" version="0011">
+                                             </sentinel-safe:resource>
+                                          </sentinel-safe:processing>
+                                       </sentinel-safe:resource>
+                                       <sentinel-safe:resource name="S3IPF PDS 004.1 - i2r7 - Product Data Format Specification - OLCI Level 1" role="Product Data Format Specification - OLCI">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3B_OL_1_EO__AX_20180618T000000_20991231T235959_20230613T120000___________________MPC_O_AL_009.SEN3" role="OLCI L1 Processing Control Parameter file in EO mode">
+                                    <sentinel-safe:processing name="AdfProcessing">
+                                       <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="1.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3IPF PDS 007.1 - Auxiliary Data Format Specification - OLCI Level 1" role="Auxiliary Data Format Specification" version="2.16">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3__AX___MA1_AX_20241217T030000_20241217T150000_20241217T174129___________________ECW_O_SN_001.SEN3" role="ECMWF Meteorological Data (Analysis) AN SFC + PL">
+                                    <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                       <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="2.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="T1D12170600121706001" role="Raw Data" version="0001">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3__AX___MA1_AX_20241217T090000_20241217T210000_20241217T174527___________________ECW_O_SN_001.SEN3" role="ECMWF Meteorological Data (Analysis) AN SFC + PL">
+                                    <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                       <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="2.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="T1D12171200121712001" role="Raw Data" version="0001">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3__AX___DEM_AX_20000101T000000_20991231T235959_20151214T120000___________________MPC_O_AL_001.SEN3" role="Digital Elevation Model GETASSE30V2">
+                                    <sentinel-safe:processing name="AdfProcessing">
+                                       <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="1.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3IPF.PDS.007 - i1r13 - Auxiliary Data Format Specification" role="Product Data Specification Document - ADFs" version="1.13">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3B_OL_1_CLUTAX_20180425T000000_20991231T235959_20240604T101747___________________MPC_O_AL_001.SEN3" role="OLCI Classification thresholds LUTs file">
+                                    <sentinel-safe:processing name="AdfProcessing">
+                                       <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="1.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3IPF PDS 007.1 - Auxiliary Data Format Specification - OLCI Level 1" role="Auxiliary Data Format Specification" version="2.9">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3B_OL_1_INS_AX_20201030T120000_20991231T235959_20220505T120000___________________MPC_O_AL_008.SEN3" role="OLCI Characterisation and Models Data file">
+                                    <sentinel-safe:processing name="AdfProcessing">
+                                       <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="1.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3IPF PDS 007.1 - Auxiliary Data Format Specification - OLCI Level 1" role="Auxiliary Data Format Specification" version="2.13">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3B_OL_1_CAL_AX_20240402T234000_20991231T235959_20240405T120000___________________MPC_O_AL_021.SEN3" role="OLCI Calibration Data file">
+                                    <sentinel-safe:processing name="AdfProcessing">
+                                       <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="1.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3IPF PDS 007.1 - Auxiliary Data Format Specification - OLCI Level 1" role="Auxiliary Data Format Specification" version="2.17">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3B_OL_1_PRG_AX_20180618T000000_20991231T235959_20240604T101746___________________MPC_O_AL_004.SEN3" role="OLCI Programmation Data file">
+                                    <sentinel-safe:processing name="AdfProcessing">
+                                       <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="1.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3IPF PDS 007.1 - Auxiliary Data Format Specification - OLCI Level 1" role="Auxiliary Data Format Specification" version="2.11">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3__AX___LWM_AX_20000101T000000_20991231T235959_20151214T120000___________________MPC_O_AL_001.SEN3" role="Land/Water Mask file">
+                                    <sentinel-safe:processing name="AdfProcessing">
+                                       <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="1.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3IPF.PDS.007 - i1r13 - Auxiliary Data Format Specification" role="Product Data Specification Document - ADFs" version="1.13">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3__AX___OOM_AX_20000101T000000_20991231T235959_20151214T120000___________________MPC_O_AL_001.SEN3" role="Open Ocean Mask file">
+                                    <sentinel-safe:processing name="AdfProcessing">
+                                       <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="1.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3IPF.PDS.007 - i1r13 - Auxiliary Data Format Specification" role="Product Data Specification Document - ADFs" version="1.13">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3__AX___CLM_AX_20000101T000000_20991231T235959_20151214T120000___________________MPC_O_AL_001.SEN3" role="Coastline Mask file">
+                                    <sentinel-safe:processing name="AdfProcessing">
+                                       <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="1.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3IPF.PDS.007 - i1r13 - Auxiliary Data Format Specification" role="Product Data Specification Document - ADFs" version="1.13">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3__AX___TRM_AX_20000101T000000_20991231T235959_20151214T120000___________________MPC_O_AL_001.SEN3" role="Tidal Regions Mask file">
+                                    <sentinel-safe:processing name="AdfProcessing">
+                                       <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="1.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3IPF.PDS.007 - i1r13 - Auxiliary Data Format Specification" role="Product Data Specification Document - ADFs" version="1.13">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3B_AX___FRO_AX_20241215T000000_20241225T000000_20241218T064322___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted);Time Correlation File">
+                                    <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                       <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="2.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3B_OPER_MPL_ORBRES_20241215T000000_20241225T000000_0001.EOF" role="Raw Data" version="0001">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                                    <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                       <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                          <sentinel-safe:hardware name="OPE"/>
+                                          <sentinel-safe:software name="ADC" version="2.0"/>
+                                       </sentinel-safe:facility>
+                                       <sentinel-safe:resource name="S3B_OPER_MPL_ORBSCT_20180425T191855_99999999T999999_0011.TGZ" role="Raw Data" version="0011">
+                                       </sentinel-safe:resource>
+                                    </sentinel-safe:processing>
+                                 </sentinel-safe:resource>
+                                 <sentinel-safe:resource name="S3IPF PDS 004.1 - i2r7 - Product Data Format Specification - OLCI Level 1" role="Product Data Format Specification - OLCI">
+                                 </sentinel-safe:resource>
+                              </sentinel-safe:processing>
+                           </sentinel-safe:resource>
+                           <sentinel-safe:resource name="S3B_OL_2_PCP_AX_20180425T000000_20991231T235959_20240425T093810___________________EUM_O_AL_004.SEN3" role="OLCI L2 Processing Control Parameters file">
+                              <sentinel-safe:processing name="AdfProcessing">
+                                 <sentinel-safe:facility name="EUM" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                    <sentinel-safe:hardware name="OPE"/>
+                                    <sentinel-safe:software name="ADC" version="1.0"/>
+                                 </sentinel-safe:facility>
+                                 <sentinel-safe:resource name="S3IPF PDS 007.2 - Auxiliary Data Format Specification - OLCI Level 2" role="Auxiliary Data Format Specification" version="2.10">
+                                 </sentinel-safe:resource>
+                              </sentinel-safe:processing>
+                           </sentinel-safe:resource>
+                           <sentinel-safe:resource name="S3B_OL_2_PPP_AX_20180425T000000_20991231T235959_20240425T093810___________________MPC_O_AL_002.SEN3" role="OLCI Pre Processing data file">
+                              <sentinel-safe:processing name="AdfProcessing">
+                                 <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                    <sentinel-safe:hardware name="OPE"/>
+                                    <sentinel-safe:software name="ADC" version="1.0"/>
+                                 </sentinel-safe:facility>
+                                 <sentinel-safe:resource name="S3IPF PDS 007.2 - Auxiliary Data Format Specification - OLCI Level 2" role="Auxiliary Data Format Specification" version="2.9">
+                                 </sentinel-safe:resource>
+                              </sentinel-safe:processing>
+                           </sentinel-safe:resource>
+                           <sentinel-safe:resource name="S3B_OL_2_WVP_AX_20180425T000000_20991231T235959_20240425T093811___________________MPC_O_AL_001.SEN3" role="OLCI Water Vapour Parameters data file">
+                              <sentinel-safe:processing name="AdfProcessing">
+                                 <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                    <sentinel-safe:hardware name="OPE"/>
+                                    <sentinel-safe:software name="ADC" version="1.0"/>
+                                 </sentinel-safe:facility>
+                                 <sentinel-safe:resource name="S3IPF PDS 007.2 - Auxiliary Data Format Specification - OLCI Level 2" role="Auxiliary Data Format Specification" version="2.9">
+                                 </sentinel-safe:resource>
+                              </sentinel-safe:processing>
+                           </sentinel-safe:resource>
+                           <sentinel-safe:resource name="S3B_OL_2_ACP_AX_20180425T000000_20991231T235959_20240425T093748___________________EUM_O_AL_004.SEN3" role="OLCI Atmospheric Correction Parameters file">
+                              <sentinel-safe:processing name="AdfProcessing">
+                                 <sentinel-safe:facility name="EUMETSAT [EUM]" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                    <sentinel-safe:hardware name="OPE"/>
+                                    <sentinel-safe:software name="ADC" version="1.0"/>
+                                 </sentinel-safe:facility>
+                                 <sentinel-safe:resource name="S3IPF PDS 007.2 - Auxiliary Data Format Specification - OLCI Level 2" role="Auxiliary Data Format Specification" version="2.10">
+                                 </sentinel-safe:resource>
+                              </sentinel-safe:processing>
+                           </sentinel-safe:resource>
+                           <sentinel-safe:resource name="S3B_OL_2_OCP_AX_20180425T000000_20991231T235959_20240425T093809___________________EUM_O_AL_004.SEN3" role="OLCI Ocean Colour Processing Parameters file">
+                              <sentinel-safe:processing name="AdfProcessing">
+                                 <sentinel-safe:facility name="EUM" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                    <sentinel-safe:hardware name="OPE"/>
+                                    <sentinel-safe:software name="ADC" version="1.0"/>
+                                 </sentinel-safe:facility>
+                                 <sentinel-safe:resource name="S3IPF PDS 007.2 - Auxiliary Data Format Specification - OLCI Level 2" role="Auxiliary Data Format Specification" version="2.10">
+                                 </sentinel-safe:resource>
+                              </sentinel-safe:processing>
+                           </sentinel-safe:resource>
+                           <sentinel-safe:resource name="S3B_OL_2_VGP_AX_20180425T000000_20991231T235959_20240425T093811___________________MPC_O_AL_001.SEN3" role="OLCI Vegetation Processing Parameters file">
+                              <sentinel-safe:processing name="AdfProcessing">
+                                 <sentinel-safe:facility name="ESA Mission Performance Coordinating Centre (MPC)" organisation="ESA Mission Performance Coordinating Centre" site="Sophia Antipolis" country="France">
+                                    <sentinel-safe:hardware name="OPE"/>
+                                    <sentinel-safe:software name="ADC" version="1.0"/>
+                                 </sentinel-safe:facility>
+                                 <sentinel-safe:resource name="S3IPF PDS 007.2 - Auxiliary Data Format Specification - OLCI Level 2" role="Auxiliary Data Format Specification" version="2.9">
+                                 </sentinel-safe:resource>
+                              </sentinel-safe:processing>
+                           </sentinel-safe:resource>
+                           <sentinel-safe:resource name="S3B_OL_2_CLP_AX_20180425T000000_20991231T235959_20240425T093807___________________EUM_O_AL_002.SEN3" role="OLCI Climatology Data file">
+                              <sentinel-safe:processing name="AdfProcessing">
+                                 <sentinel-safe:facility name="EUM" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                    <sentinel-safe:hardware name="OPE"/>
+                                    <sentinel-safe:software name="ADC" version="1.0"/>
+                                 </sentinel-safe:facility>
+                                 <sentinel-safe:resource name="S3IPF PDS 007.2 - Auxiliary Data Format Specification - OLCI Level 2" role="Auxiliary Data Format Specification" version="2.9">
+                                 </sentinel-safe:resource>
+                              </sentinel-safe:processing>
+                           </sentinel-safe:resource>
+                           <sentinel-safe:resource name="S3B_AX___OSF_AX_20180425T191855_99991231T235959_20240507T090659___________________EUM_O_AL_001.SEN3" role="Reference Orbit Scenario File">
+                              <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                 <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                    <sentinel-safe:hardware name="OPE"/>
+                                    <sentinel-safe:software name="ADC" version="2.0"/>
+                                 </sentinel-safe:facility>
+                                 <sentinel-safe:resource name="S3B_OPER_MPL_ORBSCT_20180425T191855_99999999T999999_0011.TGZ" role="Raw Data" version="0011">
+                                 </sentinel-safe:resource>
+                              </sentinel-safe:processing>
+                           </sentinel-safe:resource>
+                           <sentinel-safe:resource name="S3B_AX___FRO_AX_20241215T000000_20241225T000000_20241218T064322___________________EUM_O_AL_001.SEN3" role="FOS Orbit File (Restituted);time_init">
+                              <sentinel-safe:processing name="ADC_AUX_REFORMATTER">
+                                 <sentinel-safe:facility name="MAR" organisation="European Organisation for the Exploitation of Meteorological Satellites" site="Darmstadt" country="Germany">
+                                    <sentinel-safe:hardware name="OPE"/>
+                                    <sentinel-safe:software name="ADC" version="2.0"/>
+                                 </sentinel-safe:facility>
+                                 <sentinel-safe:resource name="S3B_OPER_MPL_ORBRES_20241215T000000_20241225T000000_0001.EOF" role="Raw Data" version="0001">
+                                 </sentinel-safe:resource>
+                              </sentinel-safe:processing>
+                           </sentinel-safe:resource>
+                           <sentinel-safe:resource name="S3IPF PDS 004.3 - i2r5 - Product Data Format Specification - OLCI Level 2 Marine" role="Product Data Format Specification - OLCI">
+                           </sentinel-safe:resource>
+                        </sentinel-safe:processing>
+                     </sentinel-safe:resource>
+                  </sentinel-safe:processing>
+               </xmlData>
+            </metadataWrap>
+         </metadataObject>
+         <metadataObject ID="geoCoordinatesAnnotation" classification="DESCRIPTION" category="DMD">
+            <dataObjectPointer dataObjectID="geoCoordinatesData"/>
+         </metadataObject>
+         <metadataObject ID="instrumentDataAnnotation" classification="DESCRIPTION" category="DMD">
+            <dataObjectPointer dataObjectID="instrumentDataData"/>
+         </metadataObject>
+         <metadataObject ID="tieGeoCoordinatesAnnotation" classification="DESCRIPTION" category="DMD">
+            <dataObjectPointer dataObjectID="tieGeoCoordinatesData"/>
+         </metadataObject>
+         <metadataObject ID="tieGeometriesAnnotation" classification="DESCRIPTION" category="DMD">
+            <dataObjectPointer dataObjectID="tieGeometriesData"/>
+         </metadataObject>
+         <metadataObject ID="tieMeteoAnnotation" classification="DESCRIPTION" category="DMD">
+            <dataObjectPointer dataObjectID="tieMeteoData"/>
+         </metadataObject>
+         <metadataObject ID="timeCoordinatesAnnotation" classification="DESCRIPTION" category="DMD">
+            <dataObjectPointer dataObjectID="timeCoordinatesData"/>
+         </metadataObject>
+         <metadataObject ID="wqsfAnnotation" classification="DESCRIPTION" category="DMD">
+            <dataObjectPointer dataObjectID="wqsfData"/>
+         </metadataObject>
+      </metadataSection>
+      <dataObjectSection>
+         <dataObject ID="Oa01_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="5693987">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa01" href="./Oa01_reflectance.nc"/>
+               <checksum checksumName="MD5">5d0a0d3ee5a73998e382ea78685706ef</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa02_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="5628298">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa02" href="./Oa02_reflectance.nc"/>
+               <checksum checksumName="MD5">aa0dc4742ccaf4d4c09f9ea7dd80adc5</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa03_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="5545782">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa03" href="./Oa03_reflectance.nc"/>
+               <checksum checksumName="MD5">2e5a95614bd470ae02c74083f9fd4e0a</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa04_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="5392092">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa04" href="./Oa04_reflectance.nc"/>
+               <checksum checksumName="MD5">c3be543e05f0a903c93d86f050ff7870</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa05_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="5356366">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa05" href="./Oa05_reflectance.nc"/>
+               <checksum checksumName="MD5">8784098804754b7139d6af5dd25e9939</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa06_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="5198899">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa06" href="./Oa06_reflectance.nc"/>
+               <checksum checksumName="MD5">06b9a36e49149bffd6f60d6032fee700</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa07_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="5120048">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa07" href="./Oa07_reflectance.nc"/>
+               <checksum checksumName="MD5">19d8a1375c945f7db2cf43fc6eda9c8f</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa08_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="4837947">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa08" href="./Oa08_reflectance.nc"/>
+               <checksum checksumName="MD5">3ca716b024270ed34b0847093d247051</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa09_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="4820649">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa09" href="./Oa09_reflectance.nc"/>
+               <checksum checksumName="MD5">53bfd7138a2732ee744ce0b9a07bb1d0</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa10_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="4760433">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa10" href="./Oa10_reflectance.nc"/>
+               <checksum checksumName="MD5">4ecf08b90208579ddeb647cfdd734453</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa11_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="4677694">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa11" href="./Oa11_reflectance.nc"/>
+               <checksum checksumName="MD5">7e0a5879f1e71734244bbb972a3da2a5</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa12_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="4374270">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa12" href="./Oa12_reflectance.nc"/>
+               <checksum checksumName="MD5">0dd26beda74e214eb32db8b032885be1</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa16_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="2665708">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa16" href="./Oa16_reflectance.nc"/>
+               <checksum checksumName="MD5">73ddc883cdc7dba983ec3e93cd891680</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa17_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="2670037">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa17" href="./Oa17_reflectance.nc"/>
+               <checksum checksumName="MD5">80f769d0712905ee4951e598f93f2ff3</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa18_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="2696013">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa18" href="./Oa18_reflectance.nc"/>
+               <checksum checksumName="MD5">64730095e7b418c719423ab0d10ceaab</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="Oa21_reflectanceData">
+            <byteStream mimeType="application/x-netcdf" size="5019005">
+               <fileLocation locatorType="URL" textInfo="Reflectance for OLCI acquisition band Oa21" href="./Oa21_reflectance.nc"/>
+               <checksum checksumName="MD5">6164180b2ab97a4fce84753b60682c21</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="chlNnData">
+            <byteStream mimeType="application/x-netcdf" size="4330285">
+               <fileLocation locatorType="URL" textInfo="Neural Net Chlorophyll concentration" href="./chl_nn.nc"/>
+               <checksum checksumName="MD5">611cb984248f0c7b71a57414f2eaa423</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="chlOc4meData">
+            <byteStream mimeType="application/x-netcdf" size="3741610">
+               <fileLocation locatorType="URL" textInfo="OC4Me algorithm Chlorophyll concentration" href="./chl_oc4me.nc"/>
+               <checksum checksumName="MD5">b088af54aa4f3aaeb31cc758dde16715</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="geoCoordinatesData">
+            <byteStream mimeType="application/x-netcdf" size="63433821">
+               <fileLocation locatorType="URL" textInfo="Geo Coordinates Annotations" href="./geo_coordinates.nc"/>
+               <checksum checksumName="MD5">d42aa2857503ea0335bf01eff51e9ece</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="instrumentDataData">
+            <byteStream mimeType="application/x-netcdf" size="827459">
+               <fileLocation locatorType="URL" textInfo="Instrument Annotation" href="./instrument_data.nc"/>
+               <checksum checksumName="MD5">22bcf2d8bc800e2c1b75c46185fac917</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="iopLsdData">
+            <byteStream mimeType="application/x-netcdf" size="29391637">
+               <fileLocation locatorType="URL" textInfo="Inherent Optical Properties of water" href="./iop_lsd.nc"/>
+               <checksum checksumName="MD5">fa5f95394992702bb883dec2364cb290</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="iopNnData">
+            <byteStream mimeType="application/x-netcdf" size="4178018">
+               <fileLocation locatorType="URL" textInfo="Inherent Optical Properties of water" href="./iop_nn.nc"/>
+               <checksum checksumName="MD5">502424d1417eb7ccb145d4f3c7f669dc</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="iwvData">
+            <byteStream mimeType="application/x-netcdf" size="8877936">
+               <fileLocation locatorType="URL" textInfo="Integrated water vapour column" href="./iwv.nc"/>
+               <checksum checksumName="MD5">90e6c00feadd7571b32df02f1a45e148</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="parData">
+            <byteStream mimeType="application/x-netcdf" size="1230224">
+               <fileLocation locatorType="URL" textInfo="Photosynthetically Active Radiation" href="./par.nc"/>
+               <checksum checksumName="MD5">5b5123aa9d4c10877b9ee69334fc3046</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="tieGeoCoordinatesData">
+            <byteStream mimeType="application/x-netcdf" size="1202465">
+               <fileLocation locatorType="URL" textInfo="Tie-Point Geo Coordinate Annotations" href="./tie_geo_coordinates.nc"/>
+               <checksum checksumName="MD5">179a07c5584da7c134a20664b2ba7638</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="tieGeometriesData">
+            <byteStream mimeType="application/x-netcdf" size="2043953">
+               <fileLocation locatorType="URL" textInfo="Tie-Point Geometries Annotations" href="./tie_geometries.nc"/>
+               <checksum checksumName="MD5">12fa873f3661e41c3bae17d4fa099486</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="tieMeteoData">
+            <byteStream mimeType="application/x-netcdf" size="19459530">
+               <fileLocation locatorType="URL" textInfo="Tie-Point Meteo Annotations" href="./tie_meteo.nc"/>
+               <checksum checksumName="MD5">980d2551675690fe9ea2cd518bd96eb7</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="timeCoordinatesData">
+            <byteStream mimeType="application/x-netcdf" size="15069">
+               <fileLocation locatorType="URL" textInfo="Time Coordinates Annotations" href="./time_coordinates.nc"/>
+               <checksum checksumName="MD5">5a636fa2dc967ce481cc66a721cea7ad</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="trspData">
+            <byteStream mimeType="application/x-netcdf" size="2137440">
+               <fileLocation locatorType="URL" textInfo="Transparency properties of water" href="./trsp.nc"/>
+               <checksum checksumName="MD5">d3fef4ea4691bb9df8744b861884ae15</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="tsmNnData">
+            <byteStream mimeType="application/x-netcdf" size="4294898">
+               <fileLocation locatorType="URL" textInfo="Total suspended matter concentration" href="./tsm_nn.nc"/>
+               <checksum checksumName="MD5">d0d6513d8e53e882c4011173695e42bf</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="wAerData">
+            <byteStream mimeType="application/x-netcdf" size="3823748">
+               <fileLocation locatorType="URL" textInfo="Aerosol Over Water" href="./w_aer.nc"/>
+               <checksum checksumName="MD5">c967d2eb880183d5ebca91d6a8769c21</checksum>
+            </byteStream>
+         </dataObject>
+         <dataObject ID="wqsfData">
+            <byteStream mimeType="application/x-netcdf" size="5628516">
+               <fileLocation locatorType="URL" textInfo="Water Quality and Science Flags" href="./wqsf.nc"/>
+               <checksum checksumName="MD5">0a2051f0bf292463e16b6eb4b42279b5</checksum>
+            </byteStream>
+         </dataObject>
+      </dataObjectSection>
+   </xfdu:XFDU>
+

--- a/tests/mock_auth.py
+++ b/tests/mock_auth.py
@@ -1,0 +1,133 @@
+"""Helper functions for mocking CDSE authentication endpoints."""
+
+import base64
+import datetime
+import json
+from typing import Any
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def mock_openid(requests_mock: Any) -> None:
+    with open("tests/credentials/mock/openid-configuration.json") as f:
+        requests_mock.get(
+            "https://identity.dataspace.copernicus.eu/auth/realms/CDSE/.well-known/openid-configuration",
+            text=f.read(),
+        )
+
+
+def mock_token(requests_mock: Any) -> None:
+    headers = {"alg": "RS256", "typ": "JWT", "kid": "key-9000"}
+    now = datetime.datetime.now()
+    payload = {
+        "exp": now.timestamp() + 3600,
+        "iat": now.timestamp(),
+        "jti": "bb4d3fab-1a39-442c-9a6f-072a167543c0",
+        "iss": "https://identity.dataspace.copernicus.eu/auth/realms/CDSE",
+        "aud": ["CLOUDFERRO_PUBLIC", "account"],
+        "sub": "bfb3df17-4506-4adf-86ab-9bb9d03f11f1",
+        "typ": "Bearer",
+        "azp": "cdse-public",
+        "session_state": "4adfd9e9-27d2-496d-9c10-bd3a54c8f1a3",
+        "allowed-origins": [
+            "https://localhost:4200",
+            "*",
+            "https://workspace.staging-cdse-data-explorer.apps.staging.intra.cloudferro.com",
+        ],
+        "realm_access": {
+            "roles": [
+                "offline_access",
+                "uma_authorization",
+                "default-roles-cdas",
+                "copernicus-general",
+            ]
+        },
+        "resource_access": {
+            "account": {
+                "roles": ["manage-account", "manage-account-links", "view-profile"]
+            }
+        },
+        "scope": "AUDIENCE_PUBLIC openid email profile user-context",
+        "sid": "03a2986d-ccfa-45e7-8e3a-55982e7e2a6e",
+        "group_membership": [
+            "/access_groups/user_typology/copernicus_general",
+            "/organizations/default-4f0080be-2b79-4837-b6a2-7f10c2b9ee1d/regular_user",
+        ],
+        "email_verified": True,
+        "organizations": ["default-4f0080be-2b79-4837-b6a2-7f10c2b9ee1d"],
+        "name": "User Full Name",
+        "user_context_id": "b9ab6ae1-83b0-433d-828f-e9e06adcc4a2",
+        "context_roles": {},
+        "context_groups": [
+            "/access_groups/user_typology/copernicus_general/",
+            "/organizations/default-4f0080be-2b79-4837-b6a2-7f10c2b9ee1d/regular_user/",
+        ],
+        "preferred_username": "user@example.com",
+        "given_name": "User first name",
+        "user_context": "default-4f0080be-2b79-4837-b6a2-7f10c2b9ee1d",
+        "family_name": "User last name",
+        "email": "user@example.com",
+    }
+
+    response = json.dumps(
+        {
+            "access_token": jwt.encode(
+                payload, private_key, algorithm="RS256", headers=headers
+            ),
+            "expires_in": 600,
+            "refresh_expires_in": 3600,
+            "refresh_token": "check-for-refresh-token-not-implementation-yet",
+            "token_type": "Bearer",
+            "not-before-policy": 0,
+            "session_state": "4adfd9e9-27d2-496d-9c10-bd3a54c8f1a3",
+            "scope": "AUDIENCE_PUBLIC openid email profile user-context",
+        }
+    )
+
+    requests_mock.post(
+        "https://identity.dataspace.copernicus.eu/auth/realms/CDSE/protocol/openid-connect/token",
+        text=response,
+    )
+
+
+def mock_jwks(mocker: Any) -> None:
+    class MockResponse:
+        def __init__(self, json_data) -> None:
+            self.json_data = json_data
+
+        def __enter__(self) -> "MockResponse":
+            return self
+
+        def read(self) -> bytes:
+            return json.dumps(self.json_data).encode("utf-8")
+
+        def __exit__(
+            self, exc_type: object, exc_value: object, traceback: object
+        ) -> None:
+            pass
+
+    n = private_key.public_key().public_numbers().n
+    e = private_key.public_key().public_numbers().e
+    n = base64.urlsafe_b64encode(
+        n.to_bytes((n.bit_length() + 7) // 8, byteorder="big")
+    ).decode("utf-8")
+    e = base64.urlsafe_b64encode(
+        e.to_bytes((e.bit_length() + 7) // 8, byteorder="big")
+    ).decode("utf-8")
+
+    jwks = {
+        "keys": [
+            {
+                "kid": "key-9000",
+                "kty": "RSA",
+                "alg": "RS256",
+                "use": "sig",
+                "n": n,
+                "e": e,
+            }
+        ]
+    }
+    mocker.patch("urllib.request.urlopen", return_value=MockResponse(jwks))


### PR DESCRIPTION
Added CLI argument '--last-baseline' to download only last available Sentinel2 processing baseline (only applicable to 'Sentinel2' collection). Query result subset is performed by a new function named 'subset_last_baseline', defined in the 'cli.py' script. Still able to merge with the new commits in the main CDSEtool repositoy.